### PR TITLE
feat(ansible): add control-plane role with kubeadm init

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -20,3 +20,10 @@
   tags: kubeadm
   roles:
     - kubeadm
+
+- name: Initialise Kubernetes control-plane
+  hosts: tag_Role_control_plane
+  become: true
+  gather_facts: true
+  roles:
+    - control-plane

--- a/ansible/roles/control-plane/tasks/kubeadm-init.yml
+++ b/ansible/roles/control-plane/tasks/kubeadm-init.yml
@@ -1,0 +1,12 @@
+---
+- name: Check if control-plane is already initialised
+  ansible.builtin.stat:
+    path: /etc/kubernetes/admin.conf
+  register: admin_conf
+
+- name: Run kubeadm init
+  ansible.builtin.command: >
+    kubeadm init
+    --pod-network-cidr=10.244.0.0/16
+    --apiserver-advertise-address={{ ansible_default_ipv4.address }}
+  when: not admin_conf.stat.exists

--- a/ansible/roles/control-plane/tasks/kubeadm-init.yml
+++ b/ansible/roles/control-plane/tasks/kubeadm-init.yml
@@ -7,6 +7,5 @@
 - name: Run kubeadm init
   ansible.builtin.command: >
     kubeadm init
-    --pod-network-cidr=10.244.0.0/16
     --apiserver-advertise-address={{ ansible_default_ipv4.address }}
   when: not admin_conf.stat.exists

--- a/ansible/roles/control-plane/tasks/kubeconfig.yml
+++ b/ansible/roles/control-plane/tasks/kubeconfig.yml
@@ -1,0 +1,13 @@
+---
+- name: Create .kube directory for root
+  ansible.builtin.file:
+    path: /root/.kube
+    state: directory
+    mode: '0700'
+
+- name: Copy admin.conf to root kubeconfig
+  ansible.builtin.copy:
+    src: /etc/kubernetes/admin.conf
+    dest: /root/.kube/config
+    remote_src: true
+    mode: '0600'

--- a/ansible/roles/control-plane/tasks/main.yml
+++ b/ansible/roles/control-plane/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- import_tasks: kubeadm-init.yml
+- import_tasks: kubeconfig.yml


### PR DESCRIPTION
## Summary
- Add `control-plane` Ansible role that initializes the Kubernetes control-plane via `kubeadm init`
- Idempotent: skips initialization if `/etc/kubernetes/admin.conf` already exists
- Copies admin kubeconfig to `/root/.kube/config` for cluster administration

## Related
Closes #5

## Test plan
- [ ] Run the playbook on a fresh `kube-1` node and verify `kubeadm init` completes
- [ ] Re-run the playbook and verify it does not re-initialize the cluster
- [ ] Verify `/root/.kube/config` exists with correct permissions (0600)