### PR TITLE
feat(terraform): provision the Azure cluster mirroring the AWS topology

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,0 +1,4 @@
+---
+kubernetes_version: "1.33"
+kubernetes_package_version: "1.33.11"
+kubernetes_pod_subnet: "10.244.0.0/16"

--- a/ansible/inventory.azure.yml
+++ b/ansible/inventory.azure.yml
@@ -1,0 +1,21 @@
+all:
+  vars:
+    ansible_user: rocky
+    ansible_ssh_private_key_file: ~/.ssh/kubequest_azure
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  children:
+    masters:
+      vars:
+        apiserver_cert_extra_sans:
+          - 20.91.198.43
+      hosts:
+        master-1:
+          ansible_host: 20.91.198.43
+    workers:
+      vars:
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand=\"ssh -W %h:%p -q -i ~/.ssh/kubequest_azure -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null rocky@20.91.198.43\""
+      hosts:
+        worker-1:
+          ansible_host: 10.42.1.7
+        worker-2:
+          ansible_host: 10.42.1.4

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -28,6 +28,13 @@
   roles:
     - control-plane
 
+- name: Deploy the Cilium CNI
+  hosts: masters
+  become: true
+  gather_facts: true
+  roles:
+    - cilium
+
 - name: Join worker nodes to the cluster
   hosts: workers
   become: true

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,20 +1,20 @@
 ---
 - name: Prepare Linux nodes for Kubernetes
-  hosts: aws_ec2
+  hosts: all
   gather_facts: true
   become: true
   roles:
     - common
 
 - name: Configure container runtime
-  hosts: aws_ec2
+  hosts: all
   become: true
   gather_facts: true
   roles:
     - containerd
 
 - name: Install Kubernetes tooling on cluster nodes
-  hosts: aws_ec2
+  hosts: all
   become: true
   gather_facts: true
   tags: kubeadm

--- a/ansible/roles/cilium/README.md
+++ b/ansible/roles/cilium/README.md
@@ -1,0 +1,34 @@
+# Cilium CNI Role
+
+## Overview
+This Ansible role deploys [Cilium](https://cilium.io/) as the CNI on the Kubernetes cluster. Without a CNI, nodes stay `NotReady` and pod-to-pod networking is unavailable. Cilium also unlocks `NetworkPolicy` enforcement, which will be leveraged for the security hardening work.
+
+## Design: vendored manifest
+The CNI is deployed from a manifest stored in the repository (`files/cilium.yaml`), never from an ad-hoc `kubectl apply <url>` or `cilium install`. The rendered manifest is checked in alongside its source `values.yaml`, so every change to the CNI is reviewable as a diff.
+
+### Regenerating the manifest
+The manifest is produced by `helm template`, not installed with `helm install` (no Tiller/Helm state on the cluster). To upgrade Cilium or change values:
+
+```sh
+helm repo add cilium https://helm.cilium.io
+helm repo update cilium
+helm template cilium cilium/cilium \
+  --version <CILIUM_VERSION> \
+  --namespace kube-system \
+  --values ansible/roles/cilium/files/values.yaml \
+  > ansible/roles/cilium/files/cilium.yaml
+```
+
+Then bump `cilium_version` in `defaults/main.yml` and commit the regenerated manifest together with the values change.
+
+## Implementation Details
+The role runs on the control-plane host and:
+1. Copies `files/cilium.yaml` to `/etc/kubernetes/manifests-extra/cilium.yaml` so the applied manifest is traceable on-node.
+2. Runs `kubectl apply -f` against the cluster's `admin.conf` kubeconfig.
+3. Waits for the `cilium` DaemonSet and the `cilium-operator` Deployment to roll out before handing over to the worker-join play.
+
+## Why These Choices?
+- **GitOps-friendly**: Since the manifest is versioned, any drift between the repo and the cluster is a bug, not a surprise. An ArgoCD/Flux migration later would be a one-file move.
+- **Cohérence du podCIDR**: The `clusterPoolIPv4PodCIDRList` in `values.yaml` matches `kubernetes_pod_subnet` passed to `kubeadm init`. Drift between the two breaks pod scheduling silently, so both are kept in sync in-repo.
+- **`kube-proxy` kept in place**: Replacing `kube-proxy` with Cilium requires `k8sServiceHost` pointing at the API server, which is cluster-specific. Baking a cluster-specific value into the vendored manifest would defeat the purpose. The switch can be done later with a templated manifest.
+- **CNI applied before workers join**: Workers will not reach `Ready` until a CNI is present. Ordering the Cilium play between control-plane init and worker join avoids a transient `NotReady` state.

--- a/ansible/roles/cilium/defaults/main.yml
+++ b/ansible/roles/cilium/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+cilium_version: "1.16.5"
+cilium_namespace: "kube-system"
+cilium_manifest_src: "cilium.yaml"
+cilium_manifest_remote_path: "/etc/kubernetes/manifests-extra/cilium.yaml"
+cilium_kubeconfig: "/etc/kubernetes/admin.conf"
+cilium_wait_timeout: "300s"

--- a/ansible/roles/cilium/files/cilium.yaml
+++ b/ansible/roles/cilium/files/cilium.yaml
@@ -1,0 +1,2072 @@
+---
+# Source: cilium/templates/cilium-agent/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "cilium"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-envoy/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "cilium-envoy"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-operator/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "cilium-operator"
+  namespace: kube-system
+---
+# Source: cilium/templates/hubble-relay/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "hubble-relay"
+  namespace: kube-system
+automountServiceAccountToken: false
+---
+# Source: cilium/templates/cilium-ca-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cilium-ca
+  namespace: kube-system
+data:
+  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRWmo5RWtxM0VyQXk4NUVBa3lwa2pXREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TkRJek1qQTBPVE01V2hjTk1qa3dOREl5TWpBMApPVE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREYxOStLczZDVHFjYmtORVo2T0xWaXh3bDBTZjZhcTJjZjYxdFBHbW5NWG1tNWc4anYKTElkRjY4Wk1PcEpYd1kwY1hzNHgzbWY1R284b0RhNzZtVWJUdEpYRmtmZ29MS2RPdUJ2QmdVWlhMK0kxdld5NwpodG9WTG5NYms2ZG5QSkRFWnR2bU5PYUJTblF5YkgzV2I0dlRGRWVLem5SdXBJT2xwczVwU25XUVRjOWFIcEovCnFOK3Z5N1VKSE5oL1VBOERmdlVtRkZCNVVtN1p2YU00TkVzQ3Q5bzBoZEUzcTc0WStnbGxsRkF6cHpub045RXQKbTZxUS9KcGR3WXRSZmI4U3JaSzFkajVQcWhDS0FFK0xWWG9ScytIait1SzF2SnVNSkxjWDduSnVacXFVN2xReQo2RjRGb1hVQk5ib3JtSS9xajMzNmFrVDFvblFSbFFTVWloNjVBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVXK01nSWwyZnBBMGM0QytqZjE2Rm9IVndPakV3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFDUmxVazQ3Z1dGZTJKUkxmcXF5KzVROFd0aGNnZjBNK2RNV3NGR2Y3M3BnOFhKYU1HOFZrMjYyCnhWM3NPRDRMYzFQdyt6akh2ejFHU05JV1dtYzRISjE5YU1KRVhqYlpFN04wSGM4WHlCZTcwQTBUWk9wdnVUR0gKOFh3dnRTbE56WVYyTVROeGhVWXV4TnBwU0EwdllEbGVVWCs1UVRaR09zTFNHMnhOYzdNZzk2TU8vQlRtcnkyWgpQZmhGelhDNkp6SWpSZXJxbXFNY2ZuSlFtMUVXcG9Za0JUOEdRc043RDZUMkF3ejZYN1Z0N21kTXVBaXUwNUE5CmhUMitjRU1XaVlPRnBTZ0JvRVZPOE9wTzFmVVoxLzlOd3gvT256ajAvRXhWTFVidkhpYnVGKzJsYXJya0tabVYKMzNxM1ptUFdweXJ2L25PUVNPMkdPb1d1c0h2b1V0ND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  ca.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBeGRmZmlyT2drNm5HNURSR2VqaTFZc2NKZEVuK21xdG5IK3RiVHhwcHpGNXB1WVBJCjd5eUhSZXZHVERxU1Y4R05IRjdPTWQ1bitScVBLQTJ1K3BsRzA3U1Z4Wkg0S0N5blRyZ2J3WUZHVnkvaU5iMXMKdTRiYUZTNXpHNU9uWnp5UXhHYmI1alRtZ1VwME1teDkxbStMMHhSSGlzNTBicVNEcGFiT2FVcDFrRTNQV2g2UwpmNmpmcjh1MUNSellmMUFQQTM3MUpoUlFlVkp1MmIyak9EUkxBcmZhTklYUk42dStHUG9KWlpSUU02YzU2RGZSCkxadXFrUHlhWGNHTFVYMi9FcTJTdFhZK1Q2b1FpZ0JQaTFWNkViUGg0L3JpdGJ5YmpDUzNGKzV5Ym1hcWxPNVUKTXVoZUJhRjFBVFc2SzVpUDZvOTkrbXBFOWFKMEVaVUVsSW9ldVFJREFRQUJBb0lCQUFSTmhFaHVvbGkrZHpEbgpZaVpaQXJqa2swbGxncFZpa2tUdUhYZVpuM1laRWp1U3FOVnEwU3V0ZG1GRXROZHJ3amM5RTBiMUMxWFk3MXdlClVCRkFodEI3NWt0UnVBL3lTS3ZtOG41QmpZSVZRZG8yc0hLenBYS1RKclc4S2JFNUdWSkJoUmw3U21MQ3pSd20KVFR1b3Jyc25LY0hVYVB2WnRYTkRoQ0c0dzRNaE9aOWozTzFoNTAwRVltN1Z3aEdoNUkyZXQ3bGhpZ0xQWHE1ZApTRyt5QnJ6b3dvOW4xcTFrQ3l1NG1kSUxwOHJpanN4cHlwN3VwS2hvVlh4U2ZVRVEzZkJFdjBIdVRyQ2ZCdmhSCnpYZDdNT3VpWFQrQTNwL1F1MXhKRklJcjBDb2R6dlBoaThUa01ZaEVGWUx1bzlZbnVnSU5hRjhyVWY5ZHEwYmsKdTlYd0ZnRUNnWUVBN2RXbElLT1FkTWtEaGdsMjNRSDZmVlljNCtic3dCQVdwOXpESkQrTllwcjhZejk3bi9CWgpnQ1ZSMmI2QUFYdkU1eWhPdnFJRVFhU2F2VUgvUEZFL3Z2VDVkS1p4SmZqOFUxK2YwRjJ4QzgzYTVoNFNmcVRWCndrZ013QVdoUGNoWkU5ME93VlhFZHl1dVhGUTM0bmdkWE9MYWhjRnJTUGdscm95WUhrQ3pMQkVDZ1lFQTFQUkkKUzQ4eHJlakJHUnRrcnJvckIxajZuSnFsbzBSWWZIQnBscjVCcHIyT0R6djVEaGdpZkVJQnRuczZ4Y0szb2pONApzVEFmdnRPSndYTnBhMWJLZ3lVZnVqSHhHMmVjeno1YXF3TGx2RTVHQnJGcFUydE14aW9tcTRnUTZzaHNPcklKClRpemtlL1psZkhsNkhNUlNzdFNRWDVLZGpDYTh0MG9US09hbkVDa0NnWUVBbE5nTFF0VDZtQXdoVjJaZTdFdkwKcjFzUU01VVcvOUJSelhZODdsZVRyVzFmbk9GakJpS09jTU5xYVVKdXEvOEFxTVl5R2Q0ZG1kTmhRQ2Fvak9BdwphOXEycjhsbXNLUVZqandmTVhFaFYwamF3UDk3QmFVMVhpUm5UbGwzb3NuYTdiS0FCSUVmdHBFd3l2bXVDOTZ1ClNhNXpvaGY5ZzZwQk11OHNXR3FYZDNFQ2dZRUFqb2w3b21lVUh3MTl3aXBkdDc0UWN2aVJ0aVNrM2FVdmZRdFoKQVhjVFJtSDJKaWhFU2JUSjBGWDJBNGgwREU2S3oxeVlXakVWN29wMDJERkJ6SURwUitLZlcrZDF0SndqajJ2egpFQ2YrVVk0cXZPd2V6YUV5WUNseWZMbTBhUklCcnovZmpwM3B5VGRoTW5HMDFIQnIwaHNKRDQ5NU9JZnRKTm5GCi9VaDFaaEVDZ1lFQWhEWUVZd2s3L3kzckNqSm9DbjhvU1QwbmtSVkJydlZsM1JIT1RKT3B5RjlzWk50VlhhdzQKMm5paTlvNGxJUVBOTmpZclQ5dk9ZNkR0MWwyOHcrZXY3dGFsMHZvalU5QU9aSE9OZWVJN2RHMzBncnphY1FlbAorenBrZEZWL01laTRQNytUcE1yVHpHR0c4MkZxa0NSY3RheVdldkgwbjVzeHFQTGh3bEdEMkFnPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
+---
+# Source: cilium/templates/hubble/tls-helm/relay-client-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hubble-relay-client-certs
+  namespace: kube-system
+type: kubernetes.io/tls
+data:
+  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRWmo5RWtxM0VyQXk4NUVBa3lwa2pXREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TkRJek1qQTBPVE01V2hjTk1qa3dOREl5TWpBMApPVE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREYxOStLczZDVHFjYmtORVo2T0xWaXh3bDBTZjZhcTJjZjYxdFBHbW5NWG1tNWc4anYKTElkRjY4Wk1PcEpYd1kwY1hzNHgzbWY1R284b0RhNzZtVWJUdEpYRmtmZ29MS2RPdUJ2QmdVWlhMK0kxdld5NwpodG9WTG5NYms2ZG5QSkRFWnR2bU5PYUJTblF5YkgzV2I0dlRGRWVLem5SdXBJT2xwczVwU25XUVRjOWFIcEovCnFOK3Z5N1VKSE5oL1VBOERmdlVtRkZCNVVtN1p2YU00TkVzQ3Q5bzBoZEUzcTc0WStnbGxsRkF6cHpub045RXQKbTZxUS9KcGR3WXRSZmI4U3JaSzFkajVQcWhDS0FFK0xWWG9ScytIait1SzF2SnVNSkxjWDduSnVacXFVN2xReQo2RjRGb1hVQk5ib3JtSS9xajMzNmFrVDFvblFSbFFTVWloNjVBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVXK01nSWwyZnBBMGM0QytqZjE2Rm9IVndPakV3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFDUmxVazQ3Z1dGZTJKUkxmcXF5KzVROFd0aGNnZjBNK2RNV3NGR2Y3M3BnOFhKYU1HOFZrMjYyCnhWM3NPRDRMYzFQdyt6akh2ejFHU05JV1dtYzRISjE5YU1KRVhqYlpFN04wSGM4WHlCZTcwQTBUWk9wdnVUR0gKOFh3dnRTbE56WVYyTVROeGhVWXV4TnBwU0EwdllEbGVVWCs1UVRaR09zTFNHMnhOYzdNZzk2TU8vQlRtcnkyWgpQZmhGelhDNkp6SWpSZXJxbXFNY2ZuSlFtMUVXcG9Za0JUOEdRc043RDZUMkF3ejZYN1Z0N21kTXVBaXUwNUE5CmhUMitjRU1XaVlPRnBTZ0JvRVZPOE9wTzFmVVoxLzlOd3gvT256ajAvRXhWTFVidkhpYnVGKzJsYXJya0tabVYKMzNxM1ptUFdweXJ2L25PUVNPMkdPb1d1c0h2b1V0ND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURTVENDQWpHZ0F3SUJBZ0lSQUtvelFuMmRDS3dvRWJldHlVZ0hhZ2N3RFFZSktvWklodmNOQVFFTEJRQXcKRkRFU01CQUdBMVVFQXhNSlEybHNhWFZ0SUVOQk1CNFhEVEkyTURReU16SXdORGt6T1ZvWERUSTNNRFF5TXpJdwpORGt6T1Zvd0l6RWhNQjhHQTFVRUF3d1lLaTVvZFdKaWJHVXRjbVZzWVhrdVkybHNhWFZ0TG1sdk1JSUJJakFOCkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQTFCMWVnQndUUERTS3I3ZTZ2S244LzROQTVHbWIKaTlSZm8xWGdNYXh1eWxKK0QrNEw3U0tqQyt1dXNmcFRxdUVRcnRjc2NHNjFXR211WEloSnEzVHRJczBuUnZyYQoyYU0xandISklNenRubkJrZlhUN1JtNEw3STI4SlliV09ISHNaeVJJbG5GTmFsd1pSZ3hlc3lTRHZkR1N1YnNOCjZyY0E0YmVSZGJHVFBVZ21jL2pMMHYwZFQwYkRMSDZjQ1ZVTkFHNmdzbmFSM01saGZIVEIyMm1uRm94WlZ4S3oKTFY5ejdyZXRja3Q4dmVXaWQvNWZ0UkhFWVc4U2FpVHplTjYyZDdUMllTWDEreXZ5RkUvMFg2WmhXdlFkSkpMMgpBK0hTUDQ5eHJtZllBYUg0bldja0VaNGc5R1NTOFVTdHJ4YTVXYlJ2SzBCeHJYUnlmOWw1NmNTWkRRSURBUUFCCm80R0dNSUdETUE0R0ExVWREd0VCL3dRRUF3SUZvREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUIKQlFVSEF3SXdEQVlEVlIwVEFRSC9CQUl3QURBZkJnTlZIU01FR0RBV2dCUmI0eUFpWFora0RSemdMNk4vWG9XZwpkWEE2TVRBakJnTlZIUkVFSERBYWdoZ3FMbWgxWW1Kc1pTMXlaV3hoZVM1amFXeHBkVzB1YVc4d0RRWUpLb1pJCmh2Y05BUUVMQlFBRGdnRUJBR1RsYXlKSnh2NHRTc1JJRW4xOUsxZVp0NlpoOERzVTNSZ0Y3MmtzRnc1QWJrcisKSFNSc2lLdmpXRWV5T3ZlYUxSUHpmVHhrZWMwZFVpMVRNbmtGWUNuZ3hmdzduZEtUREZ0VEpoNW9KNkFtQ29VNwpEYzRlazJOKytsUm4wT2xQRjc5VTRLdFlDZ2FaR0FPQmFhaHRMazMxdXY4WlN4UU81UncyZVRIbGEzd2xhTk9KCmRNbWFKT1R5SDkxUnBMMjZiYlBpWXpFbC9SUHlOWHh3V1lmUXRVZlNXckRTb01RRk44YlF2R3NzYWF0aTIvUTAKR2wyOS95Y1krUUEydFBORzRaYWcvaXBudEtDYUZ4Y2MzaVZZZGo0bUtTU2N3bmZnZ1NZTEF6T04rZDF5SlkxUAo4VzNwNzVONGMwN1hXNTh6Y1MvcnpSbTFaOFpNZEdzeTBFcUNUM3c9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBMUIxZWdCd1RQRFNLcjdlNnZLbjgvNE5BNUdtYmk5UmZvMVhnTWF4dXlsSitEKzRMCjdTS2pDK3V1c2ZwVHF1RVFydGNzY0c2MVdHbXVYSWhKcTNUdElzMG5SdnJhMmFNMWp3SEpJTXp0bm5Ca2ZYVDcKUm00TDdJMjhKWWJXT0hIc1p5UklsbkZOYWx3WlJneGVzeVNEdmRHU3Vic042cmNBNGJlUmRiR1RQVWdtYy9qTAowdjBkVDBiRExINmNDVlVOQUc2Z3NuYVIzTWxoZkhUQjIybW5Gb3haVnhLekxWOXo3cmV0Y2t0OHZlV2lkLzVmCnRSSEVZVzhTYWlUemVONjJkN1QyWVNYMSt5dnlGRS8wWDZaaFd2UWRKSkwyQStIU1A0OXhybWZZQWFING5XY2sKRVo0ZzlHU1M4VVN0cnhhNVdiUnZLMEJ4clhSeWY5bDU2Y1NaRFFJREFRQUJBb0lCQUQwR2doU3JmeUU0SUpwegphcWN5NU5ZQ1JoNHhBQTVYdUhnK2tiVFkzanNaUnFtQW5DL0tZa3hncnk4SFRTRUJoWkkzMTlJMUY3bHJGajRLCis5NzNVZTVNUmJ1WEduVzVEZ1NweDlyRytxbzF2Y09XYjJDUThwOUpHOU5VR3JlOGx2NEpvMVNkSGwrMlJaTXcKcGVJMlpDeXRhZUJEbjdwaWtqOWVWOXdiamJmNFR1dFV2Ylk2amVVa0YvRWdGTWdtQlBqWm5ycXJWNVVkUWRQdAp2UXlSQWE3NCtGcmc5bm5vV1k4eEdHUTJYdFF3YWVsSDIyU3ByaXZTTUcwZjgybGpuWVB4RzlZdlJDVjRDR3Y3ClB4SEUyZkJLVW9XSXdTeWJjcU0zSlkwcFg4eFQ1dmJaZ2ZIVU5GRDZ4T05oNm9HNFRFU0NVbzB5eUhMR3FFLzIKZTZtWkdTVUNnWUVBNGxOTUJyQzZLeTdhVkNSQ2VTWUpHbkpyakhLNHRBcnl2QmhLZjdkeFh2aG50MXgvMm80VgpEY0pVVUZtV2hXQ082eVpMYUJTc2ZOUzZ6Y3JjYUNrL2pwcmNvdFhqMTEydFJQdlliYi9kS2FRLzUzRTdkWXZXCjJUdzlLOHk3M1lOaG5seUhvTkZVd3czd0hFTHRhV1N2OFl0cGsyMFdQeVdhMlNNWjVJcmh0MnNDZ1lFQTcrMFYKOCt2dlk3RDdNcW9kNHljbEo4NkNmb084WHB1VjgzVk9OaHRjY0NUWFpvMlNHN0lqWmhXbW5pQ3Ftekc5SFY3SwpidXhZbGtPVjVHdzZSR1JsQk4zTThDQ0RIQkQzbzBkcjlSTkdqYnpQYUZ3Q1JIcS85K2Q2TGdrZFoxK2pmWEw3CkFuQk90dHN2UXd0amgxQXBNYXV3ZjBtMU1XamticndYU01zbnAyY0NnWUFUcTZtdjZ5eERGSTlsUU1HR1JnZ0UKaEcxVWg2UUdBZTJXNjRXT0ZDT0dYWkNtSHlQOW10dTVsbW85a1l2RGkrRGdEelArbDgxbURCY3dTN0ZjWERscAo2NHZCbTFWeUluSXN6TGJDMHlvbHRHRFpmTDN1T1hreTZFbG94U0tPM2h4ZDV5emlqVThRcE9WNWoxZVRFVzA1ClVTU2I2NTlEWGNGWG5mVmlKNi8yZ1FLQmdRQzdwQWx5UGtoNENEYzlWWXlRVmRJYVFza09Gd3RnVm9BODZyWmoKWEp5NzNDUldRVXhPdXRBeWk2WkdyemVlcnBTLy9wMkZpUFJ6ZUtJbkJubS9lV0VFSUUraVVWc1l2VEJmazRFYwpKNW9iU2RwUVBQMU0vMDlabThDVGRtOTNwSFdockNZaHJ5SHdvcFZnOHV4QkxIRTdOcEtQeWw2YUtQWFdvT1g0CitXR202d0tCZ0UrVWl4b2JUZ3pPSE9kaFdDblJhTk1jd0tNNnhZeXhnVjVPckp6TDBackZyNzJkSDRWNkNIREEKVWJDNFlyN1BTR1Fqa0dtRzhxYlN1UUdHemZVZHdQalBFdlBHNDhUdkdhUkI5SDBpcXRxYVNURjh5UGdnaHcrdwpGaXBVRWxBVVlNYzFjS0xCREcva0p1UllZdTdDQnhoUitKRGVzNnJrNU5Jc1p3TngzUkl1Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+---
+# Source: cilium/templates/hubble/tls-helm/server-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hubble-server-certs
+  namespace: kube-system
+type: kubernetes.io/tls
+data:
+  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRWmo5RWtxM0VyQXk4NUVBa3lwa2pXREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nall3TkRJek1qQTBPVE01V2hjTk1qa3dOREl5TWpBMApPVE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREYxOStLczZDVHFjYmtORVo2T0xWaXh3bDBTZjZhcTJjZjYxdFBHbW5NWG1tNWc4anYKTElkRjY4Wk1PcEpYd1kwY1hzNHgzbWY1R284b0RhNzZtVWJUdEpYRmtmZ29MS2RPdUJ2QmdVWlhMK0kxdld5NwpodG9WTG5NYms2ZG5QSkRFWnR2bU5PYUJTblF5YkgzV2I0dlRGRWVLem5SdXBJT2xwczVwU25XUVRjOWFIcEovCnFOK3Z5N1VKSE5oL1VBOERmdlVtRkZCNVVtN1p2YU00TkVzQ3Q5bzBoZEUzcTc0WStnbGxsRkF6cHpub045RXQKbTZxUS9KcGR3WXRSZmI4U3JaSzFkajVQcWhDS0FFK0xWWG9ScytIait1SzF2SnVNSkxjWDduSnVacXFVN2xReQo2RjRGb1hVQk5ib3JtSS9xajMzNmFrVDFvblFSbFFTVWloNjVBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVXK01nSWwyZnBBMGM0QytqZjE2Rm9IVndPakV3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFDUmxVazQ3Z1dGZTJKUkxmcXF5KzVROFd0aGNnZjBNK2RNV3NGR2Y3M3BnOFhKYU1HOFZrMjYyCnhWM3NPRDRMYzFQdyt6akh2ejFHU05JV1dtYzRISjE5YU1KRVhqYlpFN04wSGM4WHlCZTcwQTBUWk9wdnVUR0gKOFh3dnRTbE56WVYyTVROeGhVWXV4TnBwU0EwdllEbGVVWCs1UVRaR09zTFNHMnhOYzdNZzk2TU8vQlRtcnkyWgpQZmhGelhDNkp6SWpSZXJxbXFNY2ZuSlFtMUVXcG9Za0JUOEdRc043RDZUMkF3ejZYN1Z0N21kTXVBaXUwNUE5CmhUMitjRU1XaVlPRnBTZ0JvRVZPOE9wTzFmVVoxLzlOd3gvT256ajAvRXhWTFVidkhpYnVGKzJsYXJya0tabVYKMzNxM1ptUFdweXJ2L25PUVNPMkdPb1d1c0h2b1V0ND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURWekNDQWorZ0F3SUJBZ0lSQUpuRWh0VVJ2Z0pJbmM4czZZaDQzWjB3RFFZSktvWklodmNOQVFFTEJRQXcKRkRFU01CQUdBMVVFQXhNSlEybHNhWFZ0SUVOQk1CNFhEVEkyTURReU16SXdORGt6T1ZvWERUSTNNRFF5TXpJdwpORGt6T1Zvd0tqRW9NQ1lHQTFVRUF3d2ZLaTVrWldaaGRXeDBMbWgxWW1Kc1pTMW5jbkJqTG1OcGJHbDFiUzVwCmJ6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU1YU04yUTZYcTRlajI0RU5qV3UKWGpkR2E4ci9iTDhJSXFlMGFySVhRbW5yTmwzc1EwZjJHVEFzenplb3FGWDFqcTYrbnpGeURLbzEvem5xem5aKwpLZUVaMXRKLzRGcXlEaHhGNEpINTJwbFQ2cFlJS0FxaXBzZ0d0VlJISmpVZ3lkU0pQYnIrZVhtQmRucVFDV1hUCnY1TVBIQUJONDdTWlNqY0o1Yk9WMTFzblUxMlk0TFo0YkNIK1RIb2VNVXN0cW1RUkg3NCt0M1MrYTJhYWVlZlgKdmh3cWRYeXFZd3JVUm5Kak96bWlsNEJYaWQ1STF3alZIdlpxWHVMOWJNUnNmc21QQWhBNkJBT3JlNWVWRlJ3ZQpwVm9lQk1WVytiK3FpUVF3MUplZURKdzdGejdNUmtISGNWYUhvRXMxVG5qbTFoRjdXdU9NUWZVM2ZJZGt5T05IClRtRUNBd0VBQWFPQmpUQ0JpakFPQmdOVkhROEJBZjhFQkFNQ0JhQXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUgKQXdFR0NDc0dBUVVGQndNQ01Bd0dBMVVkRXdFQi93UUNNQUF3SHdZRFZSMGpCQmd3Rm9BVVcrTWdJbDJmcEEwYwo0QytqZjE2Rm9IVndPakV3S2dZRFZSMFJCQ013SVlJZktpNWtaV1poZFd4MExtaDFZbUpzWlMxbmNuQmpMbU5wCmJHbDFiUzVwYnpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVAyYkhxelRXTlB0anRwUWRWZVdTcVpDbG1pSEcKUmxMNHZRNjVSTU1tVDNSR0J2MzRHUWdFU0c1VFR2Y1phQjFaTkVOQ3MxM0RCaUYxVmxaLzNtMGV6ZWpmd002aQovYm1Bc2FTTllQVHBQVWZrQXpzOUZYeWJBSU9jOFVQczRNNCtwdytvd2JSeE1Va1lYTElYU2h3QjNFVHM2azZzCnVOWXh5L1FxU1BnTWFiM2Zia2lkdUZiOFpCMFBEdFdlamhaN3hTS3h0Q2V5bzI3QkNpMDRWMkJRQTM2dlZGUXIKQ0Fva3AyMjRPYXlMVUNQYmRDZy9VUjM4V3gvMGZiWmdKYzdlQXd5d1JzUElUZ0FZbTZIeUtaNGZnYlNvNVY3NgpJdGpkeERKMTNvQzZFVnBWdHpvMFJlVm5XdW9teTFGV0c3dndMMk94dDFyaFZBVDY2eWJaSFEvNkNRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBeGRJM1pEcGVyaDZQYmdRMk5hNWVOMFpyeXY5c3Z3Z2lwN1Jxc2hkQ2FlczJYZXhEClIvWVpNQ3pQTjZpb1ZmV09ycjZmTVhJTXFqWC9PZXJPZG40cDRSblcwbi9nV3JJT0hFWGdrZm5hbVZQcWxnZ28KQ3FLbXlBYTFWRWNtTlNESjFJazl1djU1ZVlGMmVwQUpaZE8va3c4Y0FFM2p0SmxLTndubHM1WFhXeWRUWFpqZwp0bmhzSWY1TWVoNHhTeTJxWkJFZnZqNjNkTDVyWnBwNTU5ZStIQ3AxZktwakN0UkdjbU03T2FLWGdGZUoza2pYCkNOVWU5bXBlNHYxc3hHeCt5WThDRURvRUE2dDdsNVVWSEI2bFdoNEV4VmI1djZxSkJERFVsNTRNbkRzWFBzeEcKUWNkeFZvZWdTelZPZU9iV0VYdGE0NHhCOVRkOGgyVEk0MGRPWVFJREFRQUJBb0lCQURwZlloWHl2VjUreVE4TApNaDNjQXBRbjlRWFZJamNxaE9OY3N3RXpLTmROWDJFT3B2blVqakV2ZjhQcVFpWC9UQ2VYT3kxaGZJZzdYOEVzCjN0aUxPUHRoM3dpRlVHUWkxMVFUY0lWU3AyVUlKSmc1OXVyUWZRdFlJMmluaUFnMFVTb2toekVuQnh4S0RmWnoKaXpwZlpjL1VyUXdQNzhtcVZBSnlxck8zMnZEYjM5Y0FNQTduKzFtdWJDdGZ2NDJvY282bllwQnFEK2IwYUtXYwpzUnlvOFNZczhRY01nMnpxL3AvdWtyTm1UVnh4UTFuYXluOUtweDlmQ1FmY3pLRDVISkU1SjM5a0FKMVBjTVJJCktjTTBvRVppZUYycTNpZHoySCttMjREVU5VNTFqNk5xR25Lc29sazFBUzhQSGYvRmt3dkhIemtzTnNaYlVtdzcKZTFFcW40c0NnWUVBeXpqdmFMV3BWTUxJWWtyS3FlWTFJRFBncmUzYllTeE5yM2xMTFJ3Y2ZXdmp2dTNJbFJvMwppaUxDYloyK1R1SG9UNkhwVzRINmVJU1ArRXdybjNZSzZpUzVzeTh3RzhmSk1sNi9NRmpSaTVFejhGM0ptOTBvCnB4MXFUR1lWZ3UyL1pwZTJ4b2ZhSTJ5OWJ6TVVQSGFjVTZHVjEvcDB0Z3lPNW5CTXJsSU5pcThDZ1lFQStUSXYKSDdTY2hQUGVNanBYWExrMXVPV0pBbTFHVHhNaVV6UEFIZFIyQ29taVBsVUo3QXplbGkvaGxLNFM2UmRreEFVMQpnZDNaNlBVOGt1a3BRZ1ZIVkZmZlFwTHFZMGFJZGFwRmdnUlhGUkp2SVVOajFDa2htUDU4aEdYOFNhZVB3QzVVCjhXK0hlb045WGc1RkJnZTVaaElDODhyVXd5WS9EcUJzdnZJN3UrOENnWUJNaFRxNGZiYXQ0TTRkSExaazlQYksKRWw2bWZ5cWMwMWJKSE8zdXBXZ2czZEFhbzJSa3FFT0Rjd1VzeXpuT2NBZk9mRlBuRGZFbkVoczN6azZhczVMMgppUytYUmN4aW1YNnJ4YnROMUJQSzdyalU2Q3V5MGJxdCtraDlUZThKcHNYc05uSXZIUlpKUW5ldCtGakZUNUFiCmVYdDNvS256cHBUa05pTFpmTEgycHdLQmdIRi9PdGxNOEpEWlpaVW8zMHRiQzYzWDFXd21pd1JPNmE1TmZxM1gKYTUvbkNkOHI2aVg1d3BOUzRZSlBPa3V4blBKdWtPMUNOeEtVUjI5K0JJMk9TK3VOVGlGTE9yZldreVpNVS9ZZwp0ZXppQlgxMzdRcmZaTzhDMFlHWDFhMVNSUFc1NUhSR1lNVWJDRW1EWkVxWDBBZytJZHdad0lmVmJwamgxa1d0Cm5Day9Bb0dCQUxYTXVobWRHL3BFRm5DUXRZb3FpZUtwVnZCRmV3dVZtWVhiZ01kVWV6OCtRZk5Ja2FRNGtMT0EKUyttWHdONVE1aUxZdkJjbmQrWWlPbE4zeWZ0WFVBYUZUcld6eWZSK2Y3ck5UOTRUSUh1QUoxbXVNYnZobzJlRwp0N0pDSUlmcmJlQ0tpdGFUUGl6azZSdzBEZG5zZDB2SndPOVBOMXNMQmlRbkdiV0g4eTVjCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+---
+# Source: cilium/templates/cilium-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+
+  # Identity allocation mode selects how identities are shared between cilium
+  # nodes by setting how they are stored. The options are "crd" or "kvstore".
+  # - "crd" stores identities in kubernetes as CRDs (custom resource definition).
+  #   These can be queried with:
+  #     kubectl get ciliumid
+  # - "kvstore" stores identities in an etcd kvstore, that is
+  #   configured below. Cilium versions before 1.6 supported only the kvstore
+  #   backend. Upgrades from these older cilium versions should continue using
+  #   the kvstore by commenting out the identity-allocation-mode below, or
+  #   setting it to "kvstore".
+  identity-allocation-mode: crd
+  identity-heartbeat-timeout: "30m0s"
+  identity-gc-interval: "15m0s"
+  cilium-endpoint-gc-interval: "5m0s"
+  nodes-gc-interval: "5m0s"
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  debug-verbose: ""
+  # The agent can be put into the following three policy enforcement modes
+  # default, always and never.
+  # https://docs.cilium.io/en/latest/security/policy/intro/#policy-enforcement-modes
+  enable-policy: "default"
+  policy-cidr-match-mode: ""
+  # If you want metrics enabled in cilium-operator, set the port for
+  # which the Cilium Operator will have their metrics exposed.
+  # NOTE that this will open the port on the nodes where Cilium operator pod
+  # is scheduled.
+  operator-prometheus-serve-addr: ":9963"
+  enable-metrics: "true"
+
+  # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
+  # address.
+  enable-ipv4: "true"
+
+  # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
+  # address.
+  enable-ipv6: "false"
+  # Users who wish to specify their own custom CNI configuration file must set
+  # custom-cni-conf to "true", otherwise Cilium may overwrite the configuration.
+  custom-cni-conf: "false"
+  enable-bpf-clock-probe: "false"
+  # If you want cilium monitor to aggregate tracing for packets, set this level
+  # to "low", "medium", or "maximum". The higher the level, the less packets
+  # that will be seen in monitor output.
+  monitor-aggregation: medium
+
+  # The monitor aggregation interval governs the typical time between monitor
+  # notification events for each allowed connection.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-interval: "5s"
+
+  # The monitor aggregation flags determine which TCP flags which, upon the
+  # first observation, cause monitor notifications to be generated.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-flags: all
+  # Specifies the ratio (0.0-1.0] of total system memory to use for dynamic
+  # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
+  bpf-map-dynamic-size-ratio: "0.0025"
+  # bpf-policy-map-max specifies the maximum number of entries in endpoint
+  # policy map (per endpoint)
+  bpf-policy-map-max: "16384"
+  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
+  # backend and affinity maps.
+  bpf-lb-map-max: "65536"
+  bpf-lb-external-clusterip: "false"
+
+  bpf-events-drop-enabled: "true"
+  bpf-events-policy-verdict-enabled: "true"
+  bpf-events-trace-enabled: "true"
+
+  # Pre-allocation of map entries allows per-packet latency to be reduced, at
+  # the expense of up-front memory allocation for the entries in the maps. The
+  # default value below will minimize memory usage in the default installation;
+  # users who are sensitive to latency may consider setting this to "true".
+  #
+  # This option was introduced in Cilium 1.4. Cilium 1.3 and earlier ignore
+  # this option and behave as though it is set to "true".
+  #
+  # If this value is modified, then during the next Cilium startup the restore
+  # of existing endpoints and tracking of ongoing connections may be disrupted.
+  # As a result, reply packets may be dropped and the load-balancing decisions
+  # for established connections may change.
+  #
+  # If this option is set to "false" during an upgrade from 1.3 or earlier to
+  # 1.4 or later, then it may cause one-time disruptions during the upgrade.
+  preallocate-bpf-maps: "false"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  cluster-id: "0"
+
+  # Encapsulation mode for communication between nodes
+  # Possible values:
+  #   - disabled
+  #   - vxlan (default)
+  #   - geneve
+  # Default case
+  routing-mode: "tunnel"
+  tunnel-protocol: "vxlan"
+  service-no-backend-response: "reject"
+
+
+  # Enables L7 proxy for L7 policy enforcement and visibility
+  enable-l7-proxy: "true"
+
+  enable-ipv4-masquerade: "true"
+  enable-ipv4-big-tcp: "false"
+  enable-ipv6-big-tcp: "false"
+  enable-ipv6-masquerade: "true"
+  enable-tcx: "true"
+  datapath-mode: "veth"
+  enable-masquerade-to-route-source: "false"
+
+  enable-xt-socket-fallback: "true"
+  install-no-conntrack-iptables-rules: "false"
+
+  auto-direct-node-routes: "false"
+  direct-routing-skip-unreachable: "false"
+  enable-local-redirect-policy: "false"
+  enable-runtime-device-detection: "true"
+
+  kube-proxy-replacement: "false"
+  kube-proxy-replacement-healthz-bind-address: ""
+  bpf-lb-sock: "false"
+  bpf-lb-sock-terminate-pod-connections: "false"
+  enable-host-port: "false"
+  enable-external-ips: "false"
+  enable-node-port: "false"
+  nodeport-addresses: ""
+  enable-health-check-nodeport: "true"
+  enable-health-check-loadbalancer-ip: "false"
+  node-port-bind-protection: "true"
+  enable-auto-protect-node-port-range: "true"
+  bpf-lb-acceleration: "disabled"
+  enable-svc-source-range-check: "true"
+  enable-l2-neigh-discovery: "true"
+  arping-refresh-period: "30s"
+  k8s-require-ipv4-pod-cidr: "false"
+  k8s-require-ipv6-pod-cidr: "false"
+  enable-k8s-networkpolicy: "true"
+  # Tell the agent to generate and write a CNI configuration file
+  write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
+  cni-exclusive: "true"
+  cni-log-file: "/var/run/cilium/cilium-cni.log"
+  enable-endpoint-health-checking: "true"
+  enable-health-checking: "true"
+  enable-well-known-identities: "false"
+  enable-node-selector-labels: "false"
+  synchronize-k8s-nodes: "true"
+  operator-api-serve-addr: "127.0.0.1:9234"
+  # Enable Hubble gRPC service.
+  enable-hubble: "true"
+  # UNIX domain socket for Hubble server to listen to.
+  hubble-socket-path: "/var/run/cilium/hubble.sock"
+  hubble-export-file-max-size-mb: "10"
+  hubble-export-file-max-backups: "5"
+  # An additional address for Hubble server to listen to (e.g. ":4244").
+  hubble-listen-address: ":4244"
+  hubble-disable-tls: "false"
+  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
+  hubble-tls-key-file: /var/lib/cilium/tls/hubble/server.key
+  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
+  ipam: "cluster-pool"
+  ipam-cilium-node-update-rate: "15s"
+  cluster-pool-ipv4-cidr: "10.244.0.0/16"
+  cluster-pool-ipv4-mask-size: "24"
+  egress-gateway-reconciliation-trigger-interval: "1s"
+  enable-vtep: "false"
+  vtep-endpoint: ""
+  vtep-cidr: ""
+  vtep-mask: ""
+  vtep-mac: ""
+  procfs: "/host/proc"
+  bpf-root: "/sys/fs/bpf"
+  cgroup-root: "/run/cilium/cgroupv2"
+  enable-k8s-terminating-endpoint: "true"
+  enable-sctp: "false"
+
+  k8s-client-qps: "10"
+  k8s-client-burst: "20"
+  remove-cilium-node-taints: "true"
+  set-cilium-node-taints: "true"
+  set-cilium-is-up-condition: "true"
+  unmanaged-pod-watcher-interval: "15"
+  # default DNS proxy to transparent mode in non-chaining modes
+  dnsproxy-enable-transparent-mode: "true"
+  dnsproxy-socket-linger-timeout: "10"
+  tofqdns-dns-reject-response-code: "refused"
+  tofqdns-enable-dns-compression: "true"
+  tofqdns-endpoint-max-ip-per-hostname: "50"
+  tofqdns-idle-connection-grace-period: "0s"
+  tofqdns-max-deferred-connection-deletes: "10000"
+  tofqdns-proxy-response-max-delay: "100ms"
+  agent-not-ready-taint-key: "node.cilium.io/agent-not-ready"
+
+  mesh-auth-enabled: "true"
+  mesh-auth-queue-size: "1024"
+  mesh-auth-rotated-identities-queue-size: "1024"
+  mesh-auth-gc-interval: "5m0s"
+
+  proxy-xff-num-trusted-hops-ingress: "0"
+  proxy-xff-num-trusted-hops-egress: "0"
+  proxy-connect-timeout: "2"
+  proxy-initial-fetch-timeout: "30"
+  proxy-max-requests-per-connection: "0"
+  proxy-max-connection-duration-seconds: "0"
+  proxy-idle-timeout-seconds: "60"
+
+  external-envoy-proxy: "true"
+  envoy-base-id: "0"
+
+  envoy-keep-cap-netbindservice: "false"
+  max-connected-clusters: "255"
+  clustermesh-enable-endpoint-sync: "false"
+  clustermesh-enable-mcs-api: "false"
+
+  nat-map-stats-entries: "32"
+  nat-map-stats-interval: "30s"
+
+# Extra config allows adding arbitrary properties to the cilium config.
+# By putting it at the end of the ConfigMap, it's also possible to override existing properties.
+---
+# Source: cilium/templates/cilium-envoy/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-envoy-config
+  namespace: kube-system
+data:
+  bootstrap-config.json: |
+    {
+      "node": {
+        "id": "host~127.0.0.1~no-id~localdomain",
+        "cluster": "ingress-cluster"
+      },
+      "staticResources": {
+        "listeners": [
+          {
+            "name": "envoy-prometheus-metrics-listener",
+            "address": {
+              "socket_address": {
+                "address": "0.0.0.0",
+                "port_value": 9964
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.filters.network.http_connection_manager",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                      "stat_prefix": "envoy-prometheus-metrics-listener",
+                      "route_config": {
+                        "virtual_hosts": [
+                          {
+                            "name": "prometheus_metrics_route",
+                            "domains": [
+                              "*"
+                            ],
+                            "routes": [
+                              {
+                                "name": "prometheus_metrics_route",
+                                "match": {
+                                  "prefix": "/metrics"
+                                },
+                                "route": {
+                                  "cluster": "/envoy-admin",
+                                  "prefix_rewrite": "/stats/prometheus"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "http_filters": [
+                        {
+                          "name": "envoy.filters.http.router",
+                          "typed_config": {
+                            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                          }
+                        }
+                      ],
+                      "internal_address_config": {
+                        "cidr_ranges": [
+                          {
+                            "address_prefix": "10.0.0.0",
+                            "prefix_len": 8
+                          },
+                          {
+                            "address_prefix": "172.16.0.0",
+                            "prefix_len": 12
+                          },
+                          {
+                            "address_prefix": "192.168.0.0",
+                            "prefix_len": 16
+                          },
+                          {
+                            "address_prefix": "127.0.0.1",
+                            "prefix_len": 32
+                          },
+                          {
+                            "address_prefix": "::1",
+                            "prefix_len": 128
+                          }
+                        ]
+                      },
+                      "stream_idle_timeout": "0s"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "envoy-health-listener",
+            "address": {
+              "socket_address": {
+                "address": "127.0.0.1",
+                "port_value": 9878
+              }
+            },
+            "filter_chains": [
+              {
+                "filters": [
+                  {
+                    "name": "envoy.filters.network.http_connection_manager",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                      "stat_prefix": "envoy-health-listener",
+                      "route_config": {
+                        "virtual_hosts": [
+                          {
+                            "name": "health",
+                            "domains": [
+                              "*"
+                            ],
+                            "routes": [
+                              {
+                                "name": "health",
+                                "match": {
+                                  "prefix": "/healthz"
+                                },
+                                "route": {
+                                  "cluster": "/envoy-admin",
+                                  "prefix_rewrite": "/ready"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "http_filters": [
+                        {
+                          "name": "envoy.filters.http.router",
+                          "typed_config": {
+                            "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                          }
+                        }
+                      ],
+                      "internal_address_config": {
+                        "cidr_ranges": [
+                          {
+                            "address_prefix": "10.0.0.0",
+                            "prefix_len": 8
+                          },
+                          {
+                            "address_prefix": "172.16.0.0",
+                            "prefix_len": 12
+                          },
+                          {
+                            "address_prefix": "192.168.0.0",
+                            "prefix_len": 16
+                          },
+                          {
+                            "address_prefix": "127.0.0.1",
+                            "prefix_len": 32
+                          },
+                          {
+                            "address_prefix": "::1",
+                            "prefix_len": 128
+                          }
+                        ]
+                      },
+                      "stream_idle_timeout": "0s"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "clusters": [
+          {
+            "name": "ingress-cluster",
+            "type": "ORIGINAL_DST",
+            "connectTimeout": "2s",
+            "lbPolicy": "CLUSTER_PROVIDED",
+            "typedExtensionProtocolOptions": {
+              "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                "commonHttpProtocolOptions": {
+                  "idleTimeout": "60s",
+                  "maxConnectionDuration": "0s",
+                  "maxRequestsPerConnection": 0
+                },
+                "useDownstreamProtocolConfig": {}
+              }
+            },
+            "cleanupInterval": "2.500s"
+          },
+          {
+            "name": "egress-cluster-tls",
+            "type": "ORIGINAL_DST",
+            "connectTimeout": "2s",
+            "lbPolicy": "CLUSTER_PROVIDED",
+            "typedExtensionProtocolOptions": {
+              "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                "commonHttpProtocolOptions": {
+                  "idleTimeout": "60s",
+                  "maxConnectionDuration": "0s",
+                  "maxRequestsPerConnection": 0
+                },
+                "upstreamHttpProtocolOptions": {},
+                "useDownstreamProtocolConfig": {}
+              }
+            },
+            "cleanupInterval": "2.500s",
+            "transportSocket": {
+              "name": "cilium.tls_wrapper",
+              "typedConfig": {
+                "@type": "type.googleapis.com/cilium.UpstreamTlsWrapperContext"
+              }
+            }
+          },
+          {
+            "name": "egress-cluster",
+            "type": "ORIGINAL_DST",
+            "connectTimeout": "2s",
+            "lbPolicy": "CLUSTER_PROVIDED",
+            "typedExtensionProtocolOptions": {
+              "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                "commonHttpProtocolOptions": {
+                  "idleTimeout": "60s",
+                  "maxConnectionDuration": "0s",
+                  "maxRequestsPerConnection": 0
+                },
+                "useDownstreamProtocolConfig": {}
+              }
+            },
+            "cleanupInterval": "2.500s"
+          },
+          {
+            "name": "ingress-cluster-tls",
+            "type": "ORIGINAL_DST",
+            "connectTimeout": "2s",
+            "lbPolicy": "CLUSTER_PROVIDED",
+            "typedExtensionProtocolOptions": {
+              "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                "commonHttpProtocolOptions": {
+                  "idleTimeout": "60s",
+                  "maxConnectionDuration": "0s",
+                  "maxRequestsPerConnection": 0
+                },
+                "upstreamHttpProtocolOptions": {},
+                "useDownstreamProtocolConfig": {}
+              }
+            },
+            "cleanupInterval": "2.500s",
+            "transportSocket": {
+              "name": "cilium.tls_wrapper",
+              "typedConfig": {
+                "@type": "type.googleapis.com/cilium.UpstreamTlsWrapperContext"
+              }
+            }
+          },
+          {
+            "name": "xds-grpc-cilium",
+            "type": "STATIC",
+            "connectTimeout": "2s",
+            "loadAssignment": {
+              "clusterName": "xds-grpc-cilium",
+              "endpoints": [
+                {
+                  "lbEndpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "pipe": {
+                            "path": "/var/run/cilium/envoy/sockets/xds.sock"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "typedExtensionProtocolOptions": {
+              "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                "explicitHttpConfig": {
+                  "http2ProtocolOptions": {}
+                }
+              }
+            }
+          },
+          {
+            "name": "/envoy-admin",
+            "type": "STATIC",
+            "connectTimeout": "2s",
+            "loadAssignment": {
+              "clusterName": "/envoy-admin",
+              "endpoints": [
+                {
+                  "lbEndpoints": [
+                    {
+                      "endpoint": {
+                        "address": {
+                          "pipe": {
+                            "path": "/var/run/cilium/envoy/sockets/admin.sock"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "dynamicResources": {
+        "ldsConfig": {
+          "initialFetchTimeout": "30s",
+          "apiConfigSource": {
+            "apiType": "GRPC",
+            "transportApiVersion": "V3",
+            "grpcServices": [
+              {
+                "envoyGrpc": {
+                  "clusterName": "xds-grpc-cilium"
+                }
+              }
+            ],
+            "setNodeOnFirstMessageOnly": true
+          },
+          "resourceApiVersion": "V3"
+        },
+        "cdsConfig": {
+          "initialFetchTimeout": "30s",
+          "apiConfigSource": {
+            "apiType": "GRPC",
+            "transportApiVersion": "V3",
+            "grpcServices": [
+              {
+                "envoyGrpc": {
+                  "clusterName": "xds-grpc-cilium"
+                }
+              }
+            ],
+            "setNodeOnFirstMessageOnly": true
+          },
+          "resourceApiVersion": "V3"
+        }
+      },
+      "bootstrapExtensions": [
+        {
+          "name": "envoy.bootstrap.internal_listener",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+          }
+        }
+      ],
+      "overload_manager": {
+        "resource_monitors": [
+          {
+            "name": "envoy.resource_monitors.global_downstream_max_connections",
+            "typed_config": {
+              "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+              "max_active_downstream_connections": "50000"
+            }
+          }
+        ]
+      },
+      "admin": {
+        "address": {
+          "pipe": {
+            "path": "/var/run/cilium/envoy/sockets/admin.sock"
+          }
+        }
+      }
+    }
+---
+# Source: cilium/templates/hubble-relay/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-relay-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    cluster-name: default
+    peer-service: "hubble-peer.kube-system.svc.cluster.local.:443"
+    listen-address: :4245
+    gops: true
+    gops-port: "9893"
+    dial-timeout: 
+    retry-timeout: 
+    sort-buffer-len-max: 
+    sort-buffer-drain-timeout: 
+    tls-hubble-client-cert-file: /var/lib/hubble-relay/tls/client.crt
+    tls-hubble-client-key-file: /var/lib/hubble-relay/tls/client.key
+    tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
+    
+    disable-server-tls: true
+---
+# Source: cilium/templates/cilium-agent/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - pods
+  - endpoints
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+  # This is used when validating policies in preflight. This will need to stay
+  # until we figure out how to avoid "get" inside the preflight, and then
+  # should be removed ideally.
+  - get
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumloadbalancerippools
+  - ciliumbgppeeringpolicies
+  - ciliumbgpnodeconfigs
+  - ciliumbgpadvertisements
+  - ciliumbgppeerconfigs
+  - ciliumclusterwideenvoyconfigs
+  - ciliumclusterwidenetworkpolicies
+  - ciliumegressgatewaypolicies
+  - ciliumendpoints
+  - ciliumendpointslices
+  - ciliumenvoyconfigs
+  - ciliumidentities
+  - ciliumlocalredirectpolicies
+  - ciliumnetworkpolicies
+  - ciliumnodes
+  - ciliumnodeconfigs
+  - ciliumcidrgroups
+  - ciliuml2announcementpolicies
+  - ciliumpodippools
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumidentities
+  - ciliumendpoints
+  - ciliumnodes
+  verbs:
+  - create
+- apiGroups:
+  - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpoints
+  verbs:
+  - delete
+  - get
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes
+  - ciliumnodes/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpoints/status
+  - ciliumendpoints
+  - ciliuml2announcementpolicies/status
+  - ciliumbgpnodeconfigs/status
+  verbs:
+  - patch
+---
+# Source: cilium/templates/cilium-operator/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cilium-config
+  verbs:
+   # allow patching of the configmap to set annotations
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # To remove node taints
+  - nodes
+  # To set NetworkUnavailable false on startup
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # to perform LB IP allocation for BGP
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  # to check apiserver connectivity
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumclusterwidenetworkpolicies
+  verbs:
+  # Create auto-generated CNPs and CCNPs from Policies that have 'toGroups'
+  - create
+  - update
+  - deletecollection
+  # To update the status of the CNPs and CCNPs
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies/status
+  verbs:
+  # Update the auto-generated CNPs and CCNPs status.
+  - patch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpoints
+  - ciliumidentities
+  verbs:
+  # To perform garbage collection of such resources
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumidentities
+  verbs:
+  # To synchronize garbage collection of such resources
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes
+  verbs:
+  - create
+  - update
+  - get
+  - list
+  - watch
+    # To perform CiliumNode garbage collector
+  - delete
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes/status
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpointslices
+  - ciliumenvoyconfigs
+  - ciliumbgppeerconfigs
+  - ciliumbgpadvertisements
+  - ciliumbgpnodeconfigs
+  verbs:
+  - create
+  - update
+  - get
+  - list
+  - watch
+  - delete
+  - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - update
+  resourceNames:
+  - ciliumloadbalancerippools.cilium.io
+  - ciliumbgppeeringpolicies.cilium.io
+  - ciliumbgpclusterconfigs.cilium.io
+  - ciliumbgppeerconfigs.cilium.io
+  - ciliumbgpadvertisements.cilium.io
+  - ciliumbgpnodeconfigs.cilium.io
+  - ciliumbgpnodeconfigoverrides.cilium.io
+  - ciliumclusterwideenvoyconfigs.cilium.io
+  - ciliumclusterwidenetworkpolicies.cilium.io
+  - ciliumegressgatewaypolicies.cilium.io
+  - ciliumendpoints.cilium.io
+  - ciliumendpointslices.cilium.io
+  - ciliumenvoyconfigs.cilium.io
+  - ciliumexternalworkloads.cilium.io
+  - ciliumidentities.cilium.io
+  - ciliumlocalredirectpolicies.cilium.io
+  - ciliumnetworkpolicies.cilium.io
+  - ciliumnodes.cilium.io
+  - ciliumnodeconfigs.cilium.io
+  - ciliumcidrgroups.cilium.io
+  - ciliuml2announcementpolicies.cilium.io
+  - ciliumpodippools.cilium.io
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumloadbalancerippools
+  - ciliumpodippools
+  - ciliumbgppeeringpolicies
+  - ciliumbgpclusterconfigs
+  - ciliumbgpnodeconfigoverrides
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - cilium.io
+  resources:
+    - ciliumpodippools
+  verbs:
+    - create
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumloadbalancerippools/status
+  verbs:
+  - patch
+# For cilium-operator running in HA mode.
+#
+# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
+# between multiple running instances.
+# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
+# common and fewer objects in the cluster watch "all Leases".
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+---
+# Source: cilium/templates/cilium-agent/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: "cilium"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-operator/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: "cilium-operator"
+  namespace: kube-system
+---
+# Source: cilium/templates/cilium-agent/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-config-agent
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: cilium/templates/cilium-agent/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-config-agent
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-config-agent
+subjects:
+  - kind: ServiceAccount
+    name: "cilium"
+    namespace: kube-system
+---
+# Source: cilium/templates/cilium-envoy/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-envoy
+  namespace: kube-system
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9964"
+  labels:
+    k8s-app: cilium-envoy
+    app.kubernetes.io/name: cilium-envoy
+    app.kubernetes.io/part-of: cilium
+    io.cilium/app: proxy
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector:
+    k8s-app: cilium-envoy
+  ports:
+  - name: envoy-metrics
+    port: 9964
+    protocol: TCP
+    targetPort: envoy-metrics
+---
+# Source: cilium/templates/hubble-relay/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+  annotations:
+  labels:
+    k8s-app: hubble-relay
+    app.kubernetes.io/name: hubble-relay
+    app.kubernetes.io/part-of: cilium
+spec:
+  type: "ClusterIP"
+  selector:
+    k8s-app: hubble-relay
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: grpc
+---
+# Source: cilium/templates/hubble/peer-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-peer
+  namespace: kube-system
+  labels:
+    k8s-app: cilium
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: hubble-peer
+spec:
+  selector:
+    k8s-app: cilium
+  ports:
+  - name: peer-service
+    port: 443
+    protocol: TCP
+    targetPort: 4244
+  internalTrafficPolicy: Local
+---
+# Source: cilium/templates/cilium-agent/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium
+  namespace: kube-system
+  labels:
+    k8s-app: cilium
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: cilium-agent
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 2
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        k8s-app: cilium
+        app.kubernetes.io/name: cilium-agent
+        app.kubernetes.io/part-of: cilium
+    spec:
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
+      containers:
+      - name: cilium-agent
+        image: "quay.io/cilium/cilium:v1.16.5@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+        imagePullPolicy: IfNotPresent
+        command:
+        - cilium-agent
+        args:
+        - --config-dir=/tmp/cilium/config-map
+        startupProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9879
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          failureThreshold: 105
+          periodSeconds: 2
+          successThreshold: 1
+          initialDelaySeconds: 5
+        livenessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9879
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9879
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 5
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+              divisor: '1'
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - "bash"
+              - "-c"
+              - |
+                    set -o errexit
+                    set -o pipefail
+                    set -o nounset
+                    
+                    # When running in AWS ENI mode, it's likely that 'aws-node' has
+                    # had a chance to install SNAT iptables rules. These can result
+                    # in dropped traffic, so we should attempt to remove them.
+                    # We do it using a 'postStart' hook since this may need to run
+                    # for nodes which might have already been init'ed but may still
+                    # have dangling rules. This is safe because there are no
+                    # dependencies on anything that is part of the startup script
+                    # itself, and can be safely run multiple times per node (e.g. in
+                    # case of a restart).
+                    if [[ "$(iptables-save | grep -E -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')" != "0" ]];
+                    then
+                        echo 'Deleting iptables rules created by the AWS CNI VPC plugin'
+                        iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore
+                    fi
+                    echo 'Done!'
+                    
+          preStop:
+            exec:
+              command:
+              - /cni-uninstall.sh
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - CHOWN
+              - KILL
+              - NET_ADMIN
+              - NET_RAW
+              - IPC_LOCK
+              - SYS_MODULE
+              - SYS_ADMIN
+              - SYS_RESOURCE
+              - DAC_OVERRIDE
+              - FOWNER
+              - SETGID
+              - SETUID
+            drop:
+              - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: envoy-sockets
+          mountPath: /var/run/cilium/envoy/sockets
+          readOnly: false
+        # Unprivileged containers need to mount /proc/sys/net from the host
+        # to have write access
+        - mountPath: /host/proc/sys/net
+          name: host-proc-sys-net
+        # Unprivileged containers need to mount /proc/sys/kernel from the host
+        # to have write access
+        - mountPath: /host/proc/sys/kernel
+          name: host-proc-sys-kernel
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          # Unprivileged containers can't set mount propagation to bidirectional
+          # in this case we will mount the bpf fs from an init container that
+          # is privileged and set the mount propagation from host to container
+          # in Cilium.
+          mountPropagation: HostToContainer
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        - name: etc-cni-netd
+          mountPath: /host/etc/cni/net.d
+        - name: clustermesh-secrets
+          mountPath: /var/lib/cilium/clustermesh
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+        - name: hubble-tls
+          mountPath: /var/lib/cilium/tls/hubble
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      initContainers:
+      - name: config
+        image: "quay.io/cilium/cilium:v1.16.5@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+        imagePullPolicy: IfNotPresent
+        command:
+        - cilium-dbg
+        - build-config
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        terminationMessagePolicy: FallbackToLogsOnError
+      # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
+      # We use nsenter command with host's cgroup and mount namespaces enabled.
+      - name: mount-cgroup
+        image: "quay.io/cilium/cilium:v1.16.5@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: CGROUP_ROOT
+          value: /run/cilium/cgroupv2
+        - name: BIN_PATH
+          value: /opt/cni/bin
+        command:
+        - sh
+        - -ec
+        # The statically linked Go program binary is invoked to avoid any
+        # dependency on utilities like sh and mount that can be missing on certain
+        # distros installed on the underlying host. Copy the binary to the
+        # same directory where we install cilium cni plugin so that exec permissions
+        # are available.
+        - |
+          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
+          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+          rm /hostbin/cilium-mount
+        volumeMounts:
+        - name: hostproc
+          mountPath: /hostproc
+        - name: cni-path
+          mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - SYS_ADMIN
+              - SYS_CHROOT
+              - SYS_PTRACE
+            drop:
+              - ALL
+      - name: apply-sysctl-overwrites
+        image: "quay.io/cilium/cilium:v1.16.5@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: BIN_PATH
+          value: /opt/cni/bin
+        command:
+        - sh
+        - -ec
+        # The statically linked Go program binary is invoked to avoid any
+        # dependency on utilities like sh that can be missing on certain
+        # distros installed on the underlying host. Copy the binary to the
+        # same directory where we install cilium cni plugin so that exec permissions
+        # are available.
+        - |
+          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
+          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
+          rm /hostbin/cilium-sysctlfix
+        volumeMounts:
+        - name: hostproc
+          mountPath: /hostproc
+        - name: cni-path
+          mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - SYS_ADMIN
+              - SYS_CHROOT
+              - SYS_PTRACE
+            drop:
+              - ALL
+      # Mount the bpf fs if it is not mounted. We will perform this task
+      # from a privileged container because the mount propagation bidirectional
+      # only works from privileged containers.
+      - name: mount-bpf-fs
+        image: "quay.io/cilium/cilium:v1.16.5@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+        imagePullPolicy: IfNotPresent
+        args:
+        - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
+        command:
+        - /bin/bash
+        - -c
+        - --
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
+      - name: clean-cilium-state
+        image: "quay.io/cilium/cilium:v1.16.5@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+        imagePullPolicy: IfNotPresent
+        command:
+        - /init-container.sh
+        env:
+        - name: CILIUM_ALL_STATE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: clean-cilium-state
+              optional: true
+        - name: CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: clean-cilium-bpf-state
+              optional: true
+        - name: WRITE_CNI_CONF_WHEN_READY
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: write-cni-conf-when-ready
+              optional: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - NET_ADMIN
+              - SYS_MODULE
+              - SYS_ADMIN
+              - SYS_RESOURCE
+            drop:
+              - ALL
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          # Required to mount cgroup filesystem from the host to cilium agent pod
+        - name: cilium-cgroup
+          mountPath: /run/cilium/cgroupv2
+          mountPropagation: HostToContainer
+        - name: cilium-run
+          mountPath: /var/run/cilium # wait-for-kube-proxy
+      # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
+      - name: install-cni-binaries
+        image: "quay.io/cilium/cilium:v1.16.5@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+        imagePullPolicy: IfNotPresent
+        command:
+          - "/install-plugin.sh"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            drop:
+              - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          - name: cni-path
+            mountPath: /host/opt/cni/bin # .Values.cni.install
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      serviceAccountName: "cilium"
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 1
+      hostNetwork: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      volumes:
+        # For sharing configuration between the "config" initContainer and the agent
+      - name: tmp
+        emptyDir: {}
+        # To keep state between restarts / upgrades
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        # To keep state between restarts / upgrades for bpf maps
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+      # To mount cgroup2 filesystem on the host or apply sysctlfix
+      - name: hostproc
+        hostPath:
+          path: /proc
+          type: Directory
+      # To keep state between restarts / upgrades for cgroup2 filesystem
+      - name: cilium-cgroup
+        hostPath:
+          path: /run/cilium/cgroupv2
+          type: DirectoryOrCreate
+      # To install cilium cni plugin in the host
+      - name: cni-path
+        hostPath:
+          path:  /opt/cni/bin
+          type: DirectoryOrCreate
+        # To install cilium cni configuration in the host
+      - name: etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        # To be able to load kernel modules
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+        # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      # Sharing socket with Cilium Envoy on the same node by using a host path
+      - name: envoy-sockets
+        hostPath:
+          path: "/var/run/cilium/envoy/sockets"
+          type: DirectoryOrCreate
+        # To read the clustermesh configuration
+      - name: clustermesh-secrets
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: cilium-clustermesh
+              optional: true
+              # note: items are not explicitly listed here, since the entries of this secret
+              # depend on the peers configured, and that would cause a restart of all agents
+              # at every addition/removal. Leaving the field empty makes each secret entry
+              # to be automatically projected into the volume as a file whose name is the key.
+          - secret:
+              name: clustermesh-apiserver-remote-cert
+              optional: true
+              items:
+              - key: tls.key
+                path: common-etcd-client.key
+              - key: tls.crt
+                path: common-etcd-client.crt
+              - key: ca.crt
+                path: common-etcd-client-ca.crt
+          # note: we configure the volume for the kvstoremesh-specific certificate
+          # regardless of whether KVStoreMesh is enabled or not, so that it can be
+          # automatically mounted in case KVStoreMesh gets subsequently enabled,
+          # without requiring an agent restart.
+          - secret:
+              name: clustermesh-apiserver-local-cert
+              optional: true
+              items:
+              - key: tls.key
+                path: local-etcd-client.key
+              - key: tls.crt
+                path: local-etcd-client.crt
+              - key: ca.crt
+                path: local-etcd-client-ca.crt
+      - name: host-proc-sys-net
+        hostPath:
+          path: /proc/sys/net
+          type: Directory
+      - name: host-proc-sys-kernel
+        hostPath:
+          path: /proc/sys/kernel
+          type: Directory
+      - name: hubble-tls
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: hubble-server-certs
+              optional: true
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: client-ca.crt
+---
+# Source: cilium/templates/cilium-envoy/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-envoy
+  namespace: kube-system
+  labels:
+    k8s-app: cilium-envoy
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: cilium-envoy
+    name: cilium-envoy
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-envoy
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 2
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        k8s-app: cilium-envoy
+        name: cilium-envoy
+        app.kubernetes.io/name: cilium-envoy
+        app.kubernetes.io/part-of: cilium
+    spec:
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
+      containers:
+      - name: cilium-envoy
+        image: "quay.io/cilium/cilium-envoy:v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+        imagePullPolicy: IfNotPresent
+        command:
+        - /usr/bin/cilium-envoy-starter
+        args:
+        - '--'
+        - '-c /var/run/cilium/envoy/bootstrap-config.json'
+        - '--base-id 0'
+        - '--log-level info'
+        - '--log-format [%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v'
+        startupProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9878
+            scheme: HTTP
+          failureThreshold: 105
+          periodSeconds: 2
+          successThreshold: 1
+          initialDelaySeconds: 5
+        livenessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9878
+            scheme: HTTP
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9878
+            scheme: HTTP
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 5
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        ports:
+        - name: envoy-metrics
+          containerPort: 9964
+          hostPort: 9964
+          protocol: TCP
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+              - NET_ADMIN
+              - SYS_ADMIN
+            drop:
+              - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: envoy-sockets
+          mountPath: /var/run/cilium/envoy/sockets
+          readOnly: false
+        - name: envoy-artifacts
+          mountPath: /var/run/cilium/envoy/artifacts
+          readOnly: true
+        - name: envoy-config
+          mountPath: /var/run/cilium/envoy/
+          readOnly: true
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          mountPropagation: HostToContainer
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      serviceAccountName: "cilium-envoy"
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 1
+      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cilium.io/no-schedule
+                operator: NotIn
+                values:
+                - "true"
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium-envoy
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      volumes:
+      - name: envoy-sockets
+        hostPath:
+          path: "/var/run/cilium/envoy/sockets"
+          type: DirectoryOrCreate
+      - name: envoy-artifacts
+        hostPath:
+          path: "/var/run/cilium/envoy/artifacts"
+          type: DirectoryOrCreate
+      - name: envoy-config
+        configMap:
+          name: cilium-envoy-config
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          items:
+            - key: bootstrap-config.json
+              path: bootstrap-config.json
+        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+---
+# Source: cilium/templates/cilium-operator/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: cilium-operator
+spec:
+  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
+  # for more details.
+  replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  # ensure operator update on single node k8s clusters, by using rolling update with maxUnavailable=100% in case
+  # of one replica and no user configured Recreate strategy.
+  # otherwise an update might get stuck due to the default maxUnavailable=50% in combination with the
+  # podAntiAffinity which prevents deployments of multiple operator replicas on the same node.
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 100%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9963"
+        prometheus.io/scrape: "true"
+      labels:
+        io.cilium/app: operator
+        name: cilium-operator
+        app.kubernetes.io/part-of: cilium
+        app.kubernetes.io/name: cilium-operator
+    spec:
+      containers:
+      - name: cilium-operator
+        image: "quay.io/cilium/operator-generic:v1.16.5@sha256:f7884848483bbcd7b1e0ccfd34ba4546f258b460cb4b7e2f06a1bcc96ef88039"
+        imagePullPolicy: IfNotPresent
+        command:
+        - cilium-operator-generic
+        args:
+        - --config-dir=/tmp/cilium/config-map
+        - --debug=$(CILIUM_DEBUG)
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        ports:
+        - name: prometheus
+          containerPort: 9963
+          hostPort: 9963
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 5
+        volumeMounts:
+        - name: cilium-config-path
+          mountPath: /tmp/cilium/config-map
+          readOnly: true
+        terminationMessagePolicy: FallbackToLogsOnError
+      hostNetwork: true
+      restartPolicy: Always
+      priorityClassName: system-cluster-critical
+      serviceAccountName: "cilium-operator"
+      automountServiceAccountToken: true
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                io.cilium/app: operator
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      volumes:
+        # To read the configuration from the config map
+      - name: cilium-config-path
+        configMap:
+          name: cilium-config
+---
+# Source: cilium/templates/hubble-relay/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-relay
+    app.kubernetes.io/name: hubble-relay
+    app.kubernetes.io/part-of: cilium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: hubble-relay
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        k8s-app: hubble-relay
+        app.kubernetes.io/name: hubble-relay
+        app.kubernetes.io/part-of: cilium
+    spec:
+      securityContext:
+        fsGroup: 65532
+      containers:
+        - name: hubble-relay
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+          image: "quay.io/cilium/hubble-relay:v1.16.5@sha256:6cfae1d1afa566ba941f03d4d7e141feddd05260e5cd0a1509aba1890a45ef00"
+          imagePullPolicy: IfNotPresent
+          command:
+            - hubble-relay
+          args:
+            - serve
+          ports:
+            - name: grpc
+              containerPort: 4245
+          readinessProbe:
+            grpc:
+              port: 4222
+            timeoutSeconds: 3
+          # livenessProbe will kill the pod, we should be very conservative
+          # here on failures since killing the pod should be a last resort, and
+          # we should provide enough time for relay to retry before killing it.
+          livenessProbe:
+            grpc:
+              port: 4222
+            timeoutSeconds: 10
+            # Give relay time to establish connections and make a few retries
+            # before starting livenessProbes.
+            initialDelaySeconds: 10
+            # 10 second * 12 failures = 2 minutes of failure.
+            # If relay cannot become healthy after 2 minutes, then killing it
+            # might resolve whatever issue is occurring.
+            #
+            # 10 seconds is a reasonable retry period so we can see if it's
+            # failing regularly or only sporadically.
+            periodSeconds: 10
+            failureThreshold: 12
+          startupProbe:
+            grpc:
+              port: 4222
+            # Give relay time to get it's certs and establish connections and
+            # make a few retries before starting startupProbes.
+            initialDelaySeconds: 10
+            # 20 * 3 seconds = 1 minute of failure before we consider startup as failed.
+            failureThreshold: 20
+            # Retry more frequently at startup so that it can be considered started more quickly.
+            periodSeconds: 3
+          volumeMounts:
+          - name: config
+            mountPath: /etc/hubble-relay
+            readOnly: true
+          - name: tls
+            mountPath: /var/lib/hubble-relay/tls
+            readOnly: true
+          terminationMessagePolicy: FallbackToLogsOnError
+        
+      restartPolicy: Always
+      priorityClassName: 
+      serviceAccountName: "hubble-relay"
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 1
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+      - name: config
+        configMap:
+          name: hubble-relay-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+      - name: tls
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+                - key: ca.crt
+                  path: hubble-server-ca.crt

--- a/ansible/roles/cilium/files/values.yaml
+++ b/ansible/roles/cilium/files/values.yaml
@@ -1,0 +1,35 @@
+---
+# Cilium values used to render files/cilium.yaml.
+# Regenerate the manifest with:
+#   helm repo add cilium https://helm.cilium.io
+#   helm repo update
+#   helm template cilium cilium/cilium \
+#     --version <CILIUM_VERSION> \
+#     --namespace kube-system \
+#     --values ansible/roles/cilium/files/values.yaml \
+#     > ansible/roles/cilium/files/cilium.yaml
+
+# Keep kube-proxy in place for now. Replacing kube-proxy requires
+# k8sServiceHost/Port pointing at the API server, which is cluster-specific
+# and cannot be baked into a vendored manifest. Revisit in the network-bonus
+# work when values templating is wired up.
+kubeProxyReplacement: false
+
+ipam:
+  mode: "cluster-pool"
+  operator:
+    clusterPoolIPv4PodCIDRList:
+      - "10.244.0.0/16"
+    clusterPoolIPv4MaskSize: 24
+
+# Enable Hubble for future observability work. UI stays disabled to avoid
+# exposing extra services by default.
+hubble:
+  enabled: true
+  relay:
+    enabled: true
+  ui:
+    enabled: false
+
+operator:
+  replicas: 1

--- a/ansible/roles/cilium/tasks/main.yml
+++ b/ansible/roles/cilium/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Ensure the directory for the Cilium manifest exists
+  ansible.builtin.file:
+    path: "{{ cilium_manifest_remote_path | dirname }}"
+    state: directory
+    mode: '0755'
+
+- name: Copy the vendored Cilium manifest to the control-plane
+  ansible.builtin.copy:
+    src: "{{ cilium_manifest_src }}"
+    dest: "{{ cilium_manifest_remote_path }}"
+    mode: '0644'
+  register: cilium_manifest
+
+- name: Apply the Cilium manifest
+  ansible.builtin.command:
+    cmd: "kubectl --kubeconfig={{ cilium_kubeconfig }} apply -f {{ cilium_manifest_remote_path }}"
+  register: cilium_apply
+  changed_when: "'unchanged' not in cilium_apply.stdout"
+
+- name: Wait for the Cilium agent DaemonSet to be ready
+  ansible.builtin.command:
+    cmd: >-
+      kubectl --kubeconfig={{ cilium_kubeconfig }}
+      -n {{ cilium_namespace }}
+      rollout status daemonset/cilium
+      --timeout={{ cilium_wait_timeout }}
+  changed_when: false
+
+- name: Wait for the Cilium operator Deployment to be ready
+  ansible.builtin.command:
+    cmd: >-
+      kubectl --kubeconfig={{ cilium_kubeconfig }}
+      -n {{ cilium_namespace }}
+      rollout status deployment/cilium-operator
+      --timeout={{ cilium_wait_timeout }}
+  changed_when: false

--- a/ansible/roles/common/tasks/check-nodes-binaries.yml
+++ b/ansible/roles/common/tasks/check-nodes-binaries.yml
@@ -1,4 +1,13 @@
 ---
+- name: Install the binaries required by kubeadm and Cilium
+  ansible.builtin.package:
+    name:
+      - iptables
+      - conntrack-tools
+      - socat
+      - iproute-tc
+    state: present
+
 - name: Check that the node system provides glibc
   ansible.builtin.command: ldd --version
   register: glibc_check

--- a/ansible/roles/control-plane/tasks/kubeadm-init.yml
+++ b/ansible/roles/control-plane/tasks/kubeadm-init.yml
@@ -9,4 +9,7 @@
     kubeadm init
     --apiserver-advertise-address={{ ansible_default_ipv4.address }}
     --pod-network-cidr={{ kubernetes_pod_subnet }}
+    {% if apiserver_cert_extra_sans | default([]) | length > 0 %}
+    --apiserver-cert-extra-sans={{ apiserver_cert_extra_sans | join(',') }}
+    {% endif %}
   when: not admin_conf.stat.exists

--- a/ansible/roles/control-plane/tasks/kubeadm-init.yml
+++ b/ansible/roles/control-plane/tasks/kubeadm-init.yml
@@ -8,4 +8,5 @@
   ansible.builtin.command: >
     kubeadm init
     --apiserver-advertise-address={{ ansible_default_ipv4.address }}
+    --pod-network-cidr={{ kubernetes_pod_subnet }}
   when: not admin_conf.stat.exists

--- a/ansible/roles/kubeadm/defaults/main.yml
+++ b/ansible/roles/kubeadm/defaults/main.yml
@@ -1,2 +1,3 @@
 kubernetes_version: "1.33"
 kubernetes_package_version: "1.33.11"
+kubernetes_pod_subnet: "10.244.0.0/16"

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.70.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:TtRnCnrY945AGhOJStyvYV/Ymza7YW7J4h01aF/vu98=",
+    "zh:0de702004cc5f1e4e00a723f9fdf2effa4d12f05e73d4b47a1d3b977f12ed5aa",
+    "zh:1681f026c4d802d57792d353ea97d5fa796728f854abb341c800d77b53b1e6df",
+    "zh:25f88ff759daf01310f092f06677189f5ff46b7ed0d44ea5c859ae1c1d09ba47",
+    "zh:5cf21c3cb9700d30e4f444f54f3051239a90bd0f66afb816d4404972022a6a65",
+    "zh:674e9289684754583b3b80c9cb65d054bd5f4556475ac50ffb7d7e3626f48f2f",
+    "zh:723b57d1fe6477f17e1b57663cdcc32993dcd18b7ff62352bd3c23a6df0070b1",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:990bf38be76c64ced4b612702c96373f284fefb4d8079ba8b40b834b28509729",
+    "zh:b3b062136c309f533a63baaa9789231be477be61daf51c518eeb1262a1eac683",
+    "zh:cb1009c7c318c894e773292896a9abe26f674253f5b4ad02176b7cea05134540",
+    "zh:dfb304377037ca7b800bfd1eb7586fb50a6ca3438bfeeb4a177502c850e33464",
+    "zh:eed0ddae2e7d29a53494c3a87dc89bff442dc558b4ac23887f50e58b3e9b23e0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.8.0"
+  hashes = [
+    "h1:KCuj8nPbNP/ofQrAoQIuQ3CP6k+ADpULvxr7dw2PrpM=",
+    "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",
+    "zh:563a0702e3711e25ba8930120899b681378b50cbb957fd204b37745c7c9b5f40",
+    "zh:5b56ab2ed70ed92721febb4a070af0837f1084c44825c18e4b95f7efb1d45d26",
+    "zh:6cbedc09b67a5cdb9501ff1b18a315fa46a38e0530424cab1c7f4b3acc75f489",
+    "zh:71b3bd50f89fb385a42a436ba2ce2b8e00f9de53535ce956deff1477b0b117dc",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d45ac0a00b85cabdd398b859349d17f124c598b6e6bf272f1bb01321ce708a8",
+    "zh:a453efe8641a8f31fe806b597bf2b34d7b78b971a8e3919061ea89d61fda7b8d",
+    "zh:ac692bacb8c3dca8b5b37e5383168aca1f87d3cd7b40615efd300defb76494f5",
+    "zh:bda9e90c8547d90c9c573206985c5675cc1406047605af037a5069942c3c5966",
+    "zh:c30a1967de040d00f5038086dd53cdbfb78cc05d1dbc75037410f011bf2a20d8",
+    "zh:c80bbd1c3f56b3c836d80cf93ac0e8809305c2642f0c98b54bf5d05d3b12718c",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,31 @@
+# KubeQuest - Terraform (Azure)
+
+Provisions the four Rocky Linux 9 VMs that mirror the AWS topology:
+one control-plane (static public IP) plus three workers (static public IPs).
+Tags match the AWS side (`Group`, `Role`, `Name`, `Project`).
+
+## Usage
+
+```sh
+cp terraform.tfvars.example terraform.tfvars
+# edit subscription_id at minimum
+
+terraform init
+terraform apply
+```
+
+After a successful apply, `../ansible/inventory.azure.yml` is (re)generated
+with the current public IPs. Run the playbook with:
+
+```sh
+cd ../ansible
+ansible-playbook -i inventory.azure.yml playbook.yml
+```
+
+## Notes
+
+- The Rocky Linux 9 marketplace image requires accepting a plan agreement,
+  handled by `azurerm_marketplace_agreement.rocky`.
+- `admin_username` defaults to `rocky`, the cloud image default user.
+- `allowed_ssh_cidr` defaults to `0.0.0.0/0` for convenience; tighten it
+  to your public IP for anything beyond a lab.

--- a/terraform/inventory.tf
+++ b/terraform/inventory.tf
@@ -1,0 +1,21 @@
+locals {
+  master_public_ips = { for k, v in azurerm_public_ip.master : k => v.ip_address }
+  worker_private_ips = {
+    for k, v in azurerm_network_interface.node : k => v.private_ip_address
+    if local.nodes[k].role == "worker"
+  }
+  bastion_ip = values(local.master_public_ips)[0]
+}
+
+resource "local_file" "ansible_inventory" {
+  filename        = "${path.module}/../ansible/inventory.azure.yml"
+  file_permission = "0644"
+
+  content = templatefile("${path.module}/templates/inventory.tmpl", {
+    admin_username       = var.admin_username
+    ssh_private_key_path = var.ssh_private_key_path
+    masters              = local.master_public_ips
+    workers              = local.worker_private_ips
+    bastion_ip           = local.bastion_ip
+  })
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+
+  resource_provider_registrations = "core"
+  resource_providers_to_register = [
+    "Microsoft.Compute",
+    "Microsoft.Network",
+    "Microsoft.Storage",
+    "Microsoft.MarketplaceOrdering",
+  ]
+}
+
+locals {
+  common_tags = {
+    Group   = var.group
+    Project = "KubeQuest"
+  }
+
+  masters = {
+    "master-1" = { role = "control-plane" }
+  }
+
+  workers = {
+    "worker-1" = { role = "worker" }
+    "worker-2" = { role = "worker" }
+  }
+
+  nodes = merge(local.masters, local.workers)
+}
+
+resource "azurerm_resource_group" "kubequest" {
+  name     = "rg-kubequest-${var.group}"
+  location = var.location
+  tags     = local.common_tags
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,0 +1,62 @@
+resource "azurerm_virtual_network" "kubequest" {
+  name                = "vnet-kubequest-${var.group}"
+  location            = azurerm_resource_group.kubequest.location
+  resource_group_name = azurerm_resource_group.kubequest.name
+  address_space       = ["10.42.0.0/16"]
+  tags                = local.common_tags
+}
+
+resource "azurerm_subnet" "nodes" {
+  name                 = "snet-nodes"
+  resource_group_name  = azurerm_resource_group.kubequest.name
+  virtual_network_name = azurerm_virtual_network.kubequest.name
+  address_prefixes     = ["10.42.1.0/24"]
+}
+
+resource "azurerm_network_security_group" "nodes" {
+  name                = "nsg-kubequest-${var.group}"
+  location            = azurerm_resource_group.kubequest.location
+  resource_group_name = azurerm_resource_group.kubequest.name
+  tags                = local.common_tags
+
+  security_rule {
+    name                       = "allow-ssh"
+    priority                   = 1000
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = var.allowed_ssh_cidr
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-kube-apiserver"
+    priority                   = 1010
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "6443"
+    source_address_prefix      = var.allowed_ssh_cidr
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-intra-cluster"
+    priority                   = 1100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = tolist(azurerm_virtual_network.kubequest.address_space)[0]
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "nodes" {
+  subnet_id                 = azurerm_subnet.nodes.id
+  network_security_group_id = azurerm_network_security_group.nodes.id
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "master_public_ips" {
+  description = "Static public IPs of the control-plane nodes"
+  value       = { for k, v in azurerm_public_ip.master : k => v.ip_address }
+}
+
+output "worker_private_ips" {
+  description = "Private IPs of the worker nodes (reachable through the master as SSH bastion)"
+  value       = { for k, v in azurerm_network_interface.node : k => v.private_ip_address if local.nodes[k].role == "worker" }
+}
+
+output "resource_group" {
+  description = "Azure resource group holding the cluster"
+  value       = azurerm_resource_group.kubequest.name
+}

--- a/terraform/templates/inventory.tmpl
+++ b/terraform/templates/inventory.tmpl
@@ -1,0 +1,25 @@
+all:
+  vars:
+    ansible_user: ${admin_username}
+    ansible_ssh_private_key_file: ${ssh_private_key_path}
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  children:
+    masters:
+      vars:
+        apiserver_cert_extra_sans:
+%{ for name, ip in masters ~}
+          - ${ip}
+%{ endfor ~}
+      hosts:
+%{ for name, ip in masters ~}
+        ${name}:
+          ansible_host: ${ip}
+%{ endfor ~}
+    workers:
+      vars:
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand=\"ssh -W %h:%p -q -i ${ssh_private_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${admin_username}@${bastion_ip}\""
+      hosts:
+%{ for name, ip in workers ~}
+        ${name}:
+          ansible_host: ${ip}
+%{ endfor ~}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+subscription_id      = "00000000-0000-0000-0000-000000000000"
+location             = "westeurope"
+group                = "group-41"
+vm_size              = "Standard_B2s"
+admin_username       = "rocky"
+ssh_public_key_path  = "~/.ssh/id_rsa.pub"
+ssh_private_key_path = "~/.ssh/id_rsa"
+allowed_ssh_cidr     = "0.0.0.0/0"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,76 @@
+variable "subscription_id" {
+  description = "Azure subscription ID (from Azure for Students)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region for all resources"
+  type        = string
+  default     = "westeurope"
+}
+
+variable "group" {
+  description = "Project group identifier, replicated as the Group tag"
+  type        = string
+  default     = "group-41"
+}
+
+variable "vm_size" {
+  description = "Azure VM size for every node"
+  type        = string
+  default     = "Standard_B2s"
+}
+
+variable "admin_username" {
+  description = "Admin user created on each VM (matches the Rocky cloud image default)"
+  type        = string
+  default     = "rocky"
+}
+
+variable "ssh_public_key_path" {
+  description = "Path to the SSH public key injected on every VM"
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+variable "ssh_private_key_path" {
+  description = "Path to the SSH private key used by Ansible (written into the inventory)"
+  type        = string
+  default     = "~/.ssh/id_rsa"
+}
+
+variable "allowed_ssh_cidr" {
+  description = "CIDR allowed to reach SSH (22/tcp) and the Kubernetes API (6443/tcp) from the internet"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "rocky_image" {
+  description = "Rocky Linux 9 marketplace image reference"
+  type = object({
+    publisher = string
+    offer     = string
+    sku       = string
+    version   = string
+  })
+  default = {
+    publisher = "resf"
+    offer     = "rockylinux-x86_64"
+    sku       = "9-base"
+    version   = "latest"
+  }
+}
+
+variable "rocky_plan" {
+  description = "Marketplace plan required to deploy the Rocky Linux image"
+  type = object({
+    name      = string
+    product   = string
+    publisher = string
+  })
+  default = {
+    name      = "9-base"
+    product   = "rockylinux-x86_64"
+    publisher = "resf"
+  }
+}

--- a/terraform/vms.tf
+++ b/terraform/vms.tf
@@ -1,0 +1,79 @@
+resource "azurerm_public_ip" "master" {
+  for_each = local.masters
+
+  name                = "pip-${each.key}"
+  location            = azurerm_resource_group.kubequest.location
+  resource_group_name = azurerm_resource_group.kubequest.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = merge(local.common_tags, { Role = each.value.role, Name = each.key })
+}
+
+resource "azurerm_network_interface" "node" {
+  for_each = local.nodes
+
+  name                = "nic-${each.key}"
+  location            = azurerm_resource_group.kubequest.location
+  resource_group_name = azurerm_resource_group.kubequest.name
+  tags                = merge(local.common_tags, { Role = each.value.role, Name = each.key })
+
+  ip_configuration {
+    name                          = "ipconfig1"
+    subnet_id                     = azurerm_subnet.nodes.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = each.value.role == "control-plane" ? azurerm_public_ip.master[each.key].id : null
+  }
+}
+
+resource "azurerm_marketplace_agreement" "rocky" {
+  publisher = var.rocky_plan.publisher
+  offer     = var.rocky_plan.product
+  plan      = var.rocky_plan.name
+}
+
+resource "azurerm_linux_virtual_machine" "node" {
+  for_each = local.nodes
+
+  name                            = each.key
+  computer_name                   = each.key
+  location                        = azurerm_resource_group.kubequest.location
+  resource_group_name             = azurerm_resource_group.kubequest.name
+  size                            = var.vm_size
+  admin_username                  = var.admin_username
+  disable_password_authentication = true
+  network_interface_ids           = [azurerm_network_interface.node[each.key].id]
+
+  admin_ssh_key {
+    username   = var.admin_username
+    public_key = file(pathexpand(var.ssh_public_key_path))
+  }
+
+  os_disk {
+    name                 = "osdisk-${each.key}"
+    caching              = "ReadWrite"
+    storage_account_type = "StandardSSD_LRS"
+  }
+
+  source_image_reference {
+    publisher = var.rocky_image.publisher
+    offer     = var.rocky_image.offer
+    sku       = var.rocky_image.sku
+    version   = var.rocky_image.version
+  }
+
+  plan {
+    name      = var.rocky_plan.name
+    product   = var.rocky_plan.product
+    publisher = var.rocky_plan.publisher
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Role = each.value.role
+      Name = each.key
+    },
+  )
+
+  depends_on = [azurerm_marketplace_agreement.rocky]
+}


### PR DESCRIPTION
## Summary

- Provisions a three-node Kubernetes cluster on Azure (1 master + 2 workers) with Rocky Linux 9 VMs, mirroring the tagging scheme used on AWS (`Group`, `Role`, `Name`, `Project`).
- Decouples the Ansible playbook from the AWS-specific `aws_ec2` inventory group so it runs against any inventory (AWS dynamic, Azure static, etc.), and installs the RedHat-family packages that Rocky Linux does not ship by default (`conntrack-tools`, `socat`, `iproute-tc`).
- Generates `ansible/inventory.azure.yml` at `terraform apply` time: only the master exposes a static public IP (the Azure for Students subscription caps public IPs at 3), workers are private and reached via a ProxyCommand through the master. The master public IP is also injected as a kubeadm `--apiserver-cert-extra-sans` so the emitted kubeconfig works from outside the VNet.

## Why these specific choices

- `Standard_B2s_v2` (Bsv2 family) instead of `Standard_B2s` (BS family): the BS family quota is capped at 4 vCPUs on the Students offer, Bsv2 allows 10.
- `westeurope` → `swedencentral`: the Students subscription's allowed-regions policy excludes `westeurope`.
- 2 workers instead of 3: the Total Regional Cores quota is capped at 6 vCPUs, which is exactly what 3 × 2 vCPU VMs consume.
- `resource_providers_to_register` explicitly scoped to Compute/Network/Storage/MarketplaceOrdering: the default behavior of azurerm 4.x tries to register ~60 providers tenant-wide and hangs on Students subscriptions.

## Test plan

- [x] `terraform apply` produces 3 Ready nodes with Cilium running
- [x] `kubectl get nodes` returns the three nodes with the correct roles
- [x] A test pod (nginx) is scheduled on a worker and reachable via `kubectl exec ... curl localhost`
- [x] The generated `ansible/inventory.azure.yml` can be consumed by `ansible-playbook` without modifications
- [x] `kubectl` from a developer machine works against the public master IP with the regenerated apiserver certificate
- [ ] Run the playbook against the AWS inventory to verify no regression