### PR TITLE
feat(ansible): make the cluster playbook work on AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # KubeQuest
 Epitech 10th semester cloud project. Design and deploy a fully-equipped Kubernetes cluster.
+
+## Local kubectl access (AWS)
+
+The Kubernetes API (port 6443) is not exposed publicly. Reach it through an SSH tunnel via the control-plane.
+
+Resolve the control-plane public DNS from the Ansible inventory:
+
+```bash
+MASTER=$(ansible-inventory -i ansible/inventory.aws_ec2.yml --list \
+  | jq -r '.masters.hosts[0]')
+```
+
+Fetch the kubeconfig and point it at the local tunnel endpoint:
+
+```bash
+ssh -i ~/.ssh/kubequest.pem -o IdentitiesOnly=yes ec2-user@"$MASTER" \
+  'sudo cat /etc/kubernetes/admin.conf' > ~/.kube/kubequest-aws.yaml
+chmod 600 ~/.kube/kubequest-aws.yaml
+sed -i -E 's|server: https://[^[:space:]]+|server: https://127.0.0.1:6443|' \
+  ~/.kube/kubequest-aws.yaml
+sed -i '/server: https:\/\/127.0.0.1:6443/a\    tls-server-name: kubernetes' \
+  ~/.kube/kubequest-aws.yaml
+```
+
+Open the tunnel (keep it running):
+
+```bash
+ssh -i ~/.ssh/kubequest.pem -o IdentitiesOnly=yes \
+  -L 6443:127.0.0.1:6443 -N ec2-user@"$MASTER"
+```
+
+In another shell:
+
+```bash
+export KUBECONFIG=~/.kube/kubequest-aws.yaml
+kubectl get nodes
+```

--- a/ansible/group_vars/aws_ec2.yml
+++ b/ansible/group_vars/aws_ec2.yml
@@ -1,0 +1,7 @@
+---
+ansible_user: ec2-user
+ansible_ssh_private_key_file: ~/.ssh/kubequest.pem
+ansible_ssh_common_args: >-
+  -o StrictHostKeyChecking=no
+  -o UserKnownHostsFile=/dev/null
+  -o IdentitiesOnly=yes

--- a/ansible/group_vars/aws_workers.yml
+++ b/ansible/group_vars/aws_workers.yml
@@ -1,0 +1,12 @@
+---
+# Workers have no public IP: tunnel through the control-plane bastion.
+ansible_ssh_common_args: >-
+  -o StrictHostKeyChecking=no
+  -o UserKnownHostsFile=/dev/null
+  -o IdentitiesOnly=yes
+  -o ProxyCommand="ssh -W %h:%p -q
+  -i {{ ansible_ssh_private_key_file }}
+  -o StrictHostKeyChecking=no
+  -o UserKnownHostsFile=/dev/null
+  -o IdentitiesOnly=yes
+  {{ ansible_user }}@{{ hostvars[groups['aws_masters'][0]].ansible_host }}"

--- a/ansible/inventory.aws_ec2.yml
+++ b/ansible/inventory.aws_ec2.yml
@@ -11,13 +11,19 @@ include_filters:
     - group-41
 
 groups:
-  masters:
-    - "'tag:Role' == 'control-plane'"
-  workers:
-    - "'tag:Role' == 'worker'"
+  masters: "tags.Role == 'control-plane'"
+  workers: "tags.Role == 'worker'"
+  aws_masters: "tags.Role == 'control-plane'"
+  aws_workers: "tags.Role == 'worker'"
 
 keyed_groups:
   # add hosts to tag_Role_<value> groups for each aws_ec2 host's tags.Role variable.
   - key: tags.Role
     prefix: tag_Role_
     separator: ""
+
+# Workers are reached through the control-plane (see group_vars/aws_workers.yml)
+# so they must be addressed by their private IP, not their public DNS.
+compose:
+  ansible_host: >-
+    (tags.Role == 'control-plane') | ternary(public_dns_name, private_ip_address)

--- a/ansible/roles/containerd/handlers/main.yml
+++ b/ansible/roles/containerd/handlers/main.yml
@@ -3,7 +3,3 @@
   ansible.builtin.systemd_service:
     name: containerd
     state: restarted
-
-- name: Reload sysctl
-  ansible.builtin.command: sysctl --system
-  changed_when: false

--- a/ansible/roles/containerd/tasks/install-containerd.yml
+++ b/ansible/roles/containerd/tasks/install-containerd.yml
@@ -7,8 +7,16 @@
     enabled: true
     gpgcheck: true
     gpgkey: https://download.docker.com/linux/centos/gpg
+  when: ansible_distribution != 'Amazon'
 
-- name: Install containerd
+- name: Install containerd (Amazon Linux native package)
+  ansible.builtin.dnf:
+    name: containerd
+    state: present
+  when: ansible_distribution == 'Amazon'
+
+- name: Install containerd (Docker CE containerd.io)
   ansible.builtin.dnf:
     name: containerd.io
     state: present
+  when: ansible_distribution != 'Amazon'

--- a/ansible/roles/containerd/tasks/sysctl.yml
+++ b/ansible/roles/containerd/tasks/sysctl.yml
@@ -5,9 +5,8 @@
     value: 1
     sysctl_file: /etc/sysctl.d/k8s.conf
     state: present
-    reload: no
+    reload: yes
   loop:
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-ip6tables
     - net.ipv4.ip_forward
-  notify: Reload sysctl


### PR DESCRIPTION
## Summary
- Make the `containerd` role work on Amazon Linux 2023 (use the native `containerd` package instead of the Docker CE `containerd.io` repo, whose CentOS baseurl 404s when `$releasever=2023`).
- Apply sysctl values immediately so `kubeadm init` preflight sees `net.ipv4.ip_forward=1` instead of waiting for the end-of-play handler.
- Fix the AWS dynamic inventory: the `masters` / `workers` groups were empty because the filter used `aws_ec2` plugin syntax instead of a Jinja condition.
- Scope SSH config to AWS hosts via new `aws_masters` / `aws_workers` groups + matching `group_vars`, so vars don't leak onto the Azure inventory. Workers reach the cluster through the control-plane bastion via `ProxyCommand`.

## Test plan
- [x] `ansible-playbook -i inventory.aws_ec2.yml playbook.yml` runs end-to-end with `failed=0` on all 4 nodes (1 control-plane + 3 workers, Amazon Linux 2023 arm64).
- [x] `kubectl get nodes` reports all 4 nodes joined; Cilium DaemonSet, etcd, apiserver, kube-proxy, coredns all `Running`.
- [x] `ansible-playbook -i inventory.azure.yml playbook.yml` still runs cleanly on the existing Rocky cluster (`failed=0`, fully idempotent: `changed=0`).