### PR TITLE
Fix escaping of EOL characters

### DIFF
--- a/scripts/0000-start-ec2-instances.sh
+++ b/scripts/0000-start-ec2-instances.sh
@@ -20,7 +20,7 @@ if [ -z "$INSTANCE_IDS" ]; then
   exit 0
 fi
 
-echo "Starting instances:\n$INSTANCE_IDS"
+printf "Starting instances:\n%s\n" "$INSTANCE_IDS"
 
 aws ec2 start-instances --instance-ids $INSTANCE_IDS
 

--- a/scripts/0000-stop-ec2-instances.sh
+++ b/scripts/0000-stop-ec2-instances.sh
@@ -20,7 +20,7 @@ if [ -z "$INSTANCE_IDS" ]; then
   exit 0
 fi
 
-echo "Stopping instances:\n$INSTANCE_IDS"
+printf "Stopping instances:\n%s\n" "$INSTANCE_IDS"
 
 aws ec2 stop-instances --instance-ids $INSTANCE_IDS
 


### PR DESCRIPTION
This pull request makes a minor improvement to the way instance IDs are printed in the EC2 start and stop scripts. The change switches from using `echo` to `printf` for better formatting and reliability.

* `scripts/0000-start-ec2-instances.sh`, `scripts/0000-stop-ec2-instances.sh`: Replaced `echo` with `printf` when displaying the list of instance IDs to start or stop. [[1]](diffhunk://#diff-cdfeea759061e5deb1222fdaf2593d22ef1073f3ec7d769f88f2190ec9f376b9L23-R23) [[2]](diffhunk://#diff-390ac4a31fb7b48b942e9986ec132ae43461bd547a95b862667116b918ff3bdeL23-R23)