### PR TITLE
feat(dex): Dex OIDC provider and cert-manager Helm values

### DIFF
--- a/argocd/apps/dex/application.yaml
+++ b/argocd/apps/dex/application.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dex
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/T-CLO-902-KubeQuest/KubeQuest.git
+    targetRevision: main
+    path: k8s/dex
+    directory:
+      include: "{dex.yaml,ingress.yaml}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dex
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/helm/dex/values.yaml
+++ b/helm/dex/values.yaml
@@ -1,0 +1,123 @@
+# Dex values used to render k8s/dex/dex.yaml.
+# Chart repo: https://charts.dexidp.io  (chart: dex/dex)
+# Regenerate the manifest with:
+#   helm repo add dex https://charts.dexidp.io
+#   helm repo update dex
+#   helm template dex dex/dex \
+#     --version <CHART_VERSION> \
+#     --namespace dex \
+#     --values helm/dex/values.yaml \
+#     > k8s/dex/dex.yaml
+#
+# Pinned chart version: 0.24.1 (app version 2.44.0).
+#
+# Dex is an application-level OIDC provider (Issue #10): cluster services
+# (Headlamp, Grafana, Argo CD, ...) delegate their login to Dex, which in turn
+# federates GitHub. The Kubernetes API server is NOT wired to Dex here.
+#
+# Only values that diverge from the chart defaults are set below.
+# Reference: https://dexidp.io/docs/configuration/
+
+# Single replica: this cluster has no HA requirement for the IdP.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/dexidp/dex
+  pullPolicy: IfNotPresent
+
+# Dex configuration, rendered into a Secret by the chart (configSecret.create).
+config:
+  # Public URL at which Dex is reached. MUST match the ingress host below and
+  # the issuer URL each client (Grafana, Argo CD, ...) is configured with.
+  issuer: https://dex.kubequest.epitech.beer
+
+  # Store OAuth state in Kubernetes CRDs instead of an external database.
+  storage:
+    type: kubernetes
+    config:
+      inCluster: true
+
+  # Plain HTTP inside the cluster; TLS is terminated at the ingress (like the
+  # other workloads here, Dex sits behind ingress-nginx on ClusterIP).
+  web:
+    http: 0.0.0.0:5556
+
+  oauth2:
+    skipApprovalScreen: true
+
+  # Upstream identity provider: GitHub.
+  # Secrets are injected via env vars (see envVars below) and referenced as
+  # $GITHUB_CLIENT_ID / $GITHUB_CLIENT_SECRET — never inline them here.
+  connectors:
+    - type: github
+      id: github
+      name: GitHub
+      config:
+        clientID: $GITHUB_CLIENT_ID
+        clientSecret: $GITHUB_CLIENT_SECRET
+        redirectURI: https://dex.kubequest.epitech.beer/callback
+        # Restrict and map GitHub orgs/teams to OIDC groups.
+        # orgs:
+        #   - name: my-github-org
+
+  # Services allowed to use Dex as their OIDC provider. One entry per app.
+  # Each client secret must match what the app is configured with; keep real
+  # secrets out of this file (use a sealed secret / external secret if needed).
+  staticClients:
+    - id: grafana
+      name: Grafana
+      secret: CHANGE_ME_grafana
+      redirectURIs:
+        - https://grafana.kubequest.epitech.beer/login/generic_oauth
+    - id: argocd
+      name: ArgoCD
+      secret: CHANGE_ME_argocd
+      redirectURIs:
+        - https://argocd.kubequest.epitech.beer/auth/callback
+    - id: headlamp
+      name: Headlamp
+      secret: CHANGE_ME_headlamp
+      redirectURIs:
+        - https://headlamp.kubequest.epitech.beer/oidc-callback
+
+# GitHub OAuth app credentials, sourced from a pre-created Kubernetes Secret.
+# Create it once (do NOT commit the values):
+#   kubectl -n dex create secret generic dex-github \
+#     --from-literal=clientID=<id> --from-literal=clientSecret=<secret>
+envVars:
+  - name: GITHUB_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: dex-github
+        key: clientID
+  - name: GITHUB_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: dex-github
+        key: clientSecret
+
+# Internal only; traffic reaches Dex through the standalone Ingress
+# (k8s/dex/ingress.yaml), so ClusterIP — never LoadBalancer/NodePort.
+service:
+  type: ClusterIP
+  ports:
+    http:
+      port: 5556
+
+# Ingress is declared as a standalone manifest (like Argo CD's and Headlamp's,
+# in k8s/dex/ingress.yaml) so TLS via cert-manager lives next to it and stays a
+# reviewable diff. Keep the chart's own Ingress off to avoid two sources.
+ingress:
+  enabled: false
+
+serviceAccount:
+  create: true
+
+# Constrained cluster: cap Dex rather than let it burst.
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi

--- a/k8s/dex/README.md
+++ b/k8s/dex/README.md
@@ -1,0 +1,65 @@
+# Dex (OIDC provider)
+
+## Overview
+[Dex](https://dexidp.io/) is the cluster's application-level OIDC provider
+(Issue #10). Cluster services — Headlamp, Grafana, Argo CD, ... — delegate their
+login to Dex, which in turn **federates GitHub** as the upstream identity
+provider. The Kubernetes API server is **not** wired to Dex here; this is SSO for
+the dashboards/apps, not for `kubectl`.
+
+This is the single, cluster-wide Dex the Argo CD install intentionally leaves
+out of its own bundle (see `argocd/README.md` → "Minimal footprint"). Wire Argo
+CD's SSO to it later via `oidc.config` in `argocd-cm`.
+
+## Design: vendored manifest
+Like the Cilium CNI, Argo CD, ingress-nginx and Headlamp, Dex is installed from a
+manifest checked into the repo (`k8s/dex/dex.yaml`), rendered with `helm
+template` — never `helm install` (no Helm release state on the cluster). Every
+change is a reviewable diff alongside its source values (`helm/dex/values.yaml`).
+
+### Regenerating the manifest
+```sh
+helm repo add dex https://charts.dexidp.io
+helm repo update dex
+helm template dex dex/dex \
+  --version <CHART_VERSION> \
+  --namespace dex \
+  --values helm/dex/values.yaml \
+  > k8s/dex/dex.yaml
+```
+Pinned chart version: **0.24.1** (app version 2.44.0). Bump it here and in the
+command above, then commit the regenerated manifest with the values change.
+
+## Exposure & TLS
+The `Service` stays `ClusterIP` (port 5556, plain HTTP); real traffic reaches Dex
+through a standalone `Ingress` (`k8s/dex/ingress.yaml`) on the `nginx`
+IngressClass, with TLS issued by cert-manager. As with Argo CD and Headlamp, the
+Ingress starts on the `letsencrypt-staging` issuer to validate HTTP-01 end to
+end, then switches to `letsencrypt-prod` once a staging cert is issued.
+
+Target host: **https://dex.kubequest.epitech.beer** — this MUST match
+`config.issuer` in the values and every client's configured issuer URL.
+
+## GitHub OAuth credentials
+Dex federates GitHub via a GitHub OAuth App. Its credentials are **not** in Git;
+they come from a Secret created once in the `dex` namespace:
+```sh
+kubectl -n dex create secret generic dex-github \
+  --from-literal=clientID=<id> \
+  --from-literal=clientSecret=<secret>
+```
+The OAuth App's *Authorization callback URL* must be
+`https://dex.kubequest.epitech.beer/callback`.
+
+## Clients
+Each service that logs in through Dex is declared as a `staticClient` in
+`helm/dex/values.yaml` (Grafana, Argo CD, Headlamp). The placeholder
+`CHANGE_ME_*` secrets are committed only as a shape; replace them with real
+shared secrets (sealed/external secret) that match each app's configuration. A
+client's `redirectURIs` must exactly match what the app sends.
+
+## Deployment
+Managed by GitOps: the `Application` at `argocd/apps/dex/application.yaml` is
+picked up by the root app-of-apps and synced automatically. No manual
+`kubectl apply` — but the `dex-github` Secret above must exist in the namespace
+before the GitHub connector can start.

--- a/k8s/dex/dex.yaml
+++ b/k8s/dex/dex.yaml
@@ -1,0 +1,221 @@
+---
+# Source: dex/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dex
+  namespace: dex
+  labels:
+    helm.sh/chart: dex-0.24.1
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/version: "2.44.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: dex/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex
+  namespace: dex
+  labels:
+    helm.sh/chart: dex-0.24.1
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/version: "2.44.0"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  config.yaml: "Y29ubmVjdG9yczoKLSBjb25maWc6CiAgICBjbGllbnRJRDogJEdJVEhVQl9DTElFTlRfSUQKICAgIGNsaWVudFNlY3JldDogJEdJVEhVQl9DTElFTlRfU0VDUkVUCiAgICByZWRpcmVjdFVSSTogaHR0cHM6Ly9kZXgua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9jYWxsYmFjawogIGlkOiBnaXRodWIKICBuYW1lOiBHaXRIdWIKICB0eXBlOiBnaXRodWIKaXNzdWVyOiBodHRwczovL2RleC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyCm9hdXRoMjoKICBza2lwQXBwcm92YWxTY3JlZW46IHRydWUKc3RhdGljQ2xpZW50czoKLSBpZDogZ3JhZmFuYQogIG5hbWU6IEdyYWZhbmEKICByZWRpcmVjdFVSSXM6CiAgLSBodHRwczovL2dyYWZhbmEua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9sb2dpbi9nZW5lcmljX29hdXRoCiAgc2VjcmV0OiBDSEFOR0VfTUVfZ3JhZmFuYQotIGlkOiBhcmdvY2QKICBuYW1lOiBBcmdvQ0QKICByZWRpcmVjdFVSSXM6CiAgLSBodHRwczovL2FyZ29jZC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyL2F1dGgvY2FsbGJhY2sKICBzZWNyZXQ6IENIQU5HRV9NRV9hcmdvY2QKLSBpZDogaGVhZGxhbXAKICBuYW1lOiBIZWFkbGFtcAogIHJlZGlyZWN0VVJJczoKICAtIGh0dHBzOi8vaGVhZGxhbXAua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9vaWRjLWNhbGxiYWNrCiAgc2VjcmV0OiBDSEFOR0VfTUVfaGVhZGxhbXAKc3RvcmFnZToKICBjb25maWc6CiAgICBpbkNsdXN0ZXI6IHRydWUKICB0eXBlOiBrdWJlcm5ldGVzCndlYjoKICBodHRwOiAwLjAuMC4wOjU1NTY="
+---
+# Source: dex/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dex
+  labels:
+    helm.sh/chart: dex-0.24.1
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/version: "2.44.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["list", "create"]
+---
+# Source: dex/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dex-cluster
+  labels:
+    helm.sh/chart: dex-0.24.1
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/version: "2.44.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: dex
+subjects:
+- kind: ServiceAccount
+  namespace: dex
+  name: dex
+---
+# Source: dex/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dex
+  namespace: dex
+  labels:
+    helm.sh/chart: dex-0.24.1
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/version: "2.44.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: ["dex.coreos.com"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+# Source: dex/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dex
+  namespace: dex
+  labels:
+    helm.sh/chart: dex-0.24.1
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/version: "2.44.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: dex
+subjects:
+- kind: ServiceAccount
+  namespace: dex
+  name: dex
+---
+# Source: dex/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: dex
+  labels:
+    helm.sh/chart: dex-0.24.1
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/version: "2.44.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 5556
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+    - name: telemetry
+      port: 5558
+      targetPort: telemetry
+      protocol: TCP
+      appProtocol: http
+  selector:
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/instance: dex
+---
+# Source: dex/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: dex
+  labels:
+    helm.sh/chart: dex-0.24.1
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/version: "2.44.0"
+    app.kubernetes.io/managed-by: Helm
+    
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dex
+      app.kubernetes.io/instance: dex
+  template:
+    metadata:
+      annotations:
+      
+        checksum/config: bbf21ca2305d2cde693014a24807be9f89caedb55d96cbe1128cfee1a373e4e8
+      labels:
+        app.kubernetes.io/name: dex
+        app.kubernetes.io/instance: dex
+    spec:
+      serviceAccountName: dex
+      securityContext:
+        {}
+      containers:
+        - name: dex
+          securityContext:
+            {}
+          image: "ghcr.io/dexidp/dex:v2.44.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - dex
+            - serve
+            - --web-http-addr
+            - 0.0.0.0:5556
+            - --telemetry-addr
+            - 0.0.0.0:5558
+            - /etc/dex/config.yaml
+          env:
+            - name: GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: clientID
+                  name: dex-github
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: clientSecret
+                  name: dex-github
+          ports:
+            - name: http
+              containerPort: 5556
+              protocol: TCP
+            - name: telemetry
+              containerPort: 5558
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/live
+              port: telemetry
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: telemetry
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: dex

--- a/k8s/dex/ingress.yaml
+++ b/k8s/dex/ingress.yaml
@@ -1,0 +1,32 @@
+# Ingress exposing the Dex OIDC provider at dex.kubequest.epitech.beer.
+#
+# Dex serves plain HTTP on its Service (port 5556), so no backend-protocol
+# annotation is needed — HTTP is ingress-nginx's default.
+#
+# Starts on the staging issuer to validate HTTP-01 end to end. Once a staging
+# cert is issued, switch the cert-manager.io/cluster-issuer annotation to
+# letsencrypt-prod and delete the staging secret to force a prod re-issue.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dex
+  namespace: dex
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - dex.kubequest.epitech.beer
+      secretName: dex-tls
+  rules:
+    - host: dex.kubequest.epitech.beer
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dex
+                port:
+                  number: 5556


### PR DESCRIPTION
## Contexte
Met en place les bases pour l'authentification OIDC des services exposés du cluster (Headlamp, Grafana, ArgoCD, ...). Dex sert d'IdP applicatif fédérant **GitHub** ; cert-manager fournit les certificats TLS Let's Encrypt.

> Déploiement prévu **plus tard via ArgoCD** — cette PR n'ajoute que les value overrides Helm vendorés et les manifestes ClusterIssuer. Aucun code Ansible.

## Contenu
- `helm/dex/values.yaml` — overrides du chart `dex/dex` : connecteur GitHub, `staticClients` (Grafana/ArgoCD/Headlamp), storage Kubernetes (CRD), ingress relié à cert-manager.
- `helm/cert-manager/values.yaml` — overrides du chart `jetstack/cert-manager` v1.20.2 (CRDs incluses).
- `k8s/cert-manager/clusterissuer-letsencrypt-{staging,prod}.yaml` — émetteurs ACME Let's Encrypt, challenge HTTP-01.

## Reste à faire avant déploiement
- [ ] Un **ingress controller** dans le cluster (absent pour l'instant) + renseigner `ingressClassName` / `className`.
- [ ] Enregistrements **DNS** `*.kubequest.epitech.beer` vers l'ingress.
- [ ] Email réel pour Let's Encrypt (remplacer `admin@epitech.beer`).
- [ ] **OAuth App GitHub** + Secret `dex-github`, et remplacer les secrets clients `CHANGE_ME_*`.
- [ ] Valider en **staging** puis basculer l'annotation Dex sur `letsencrypt-prod`.

## Tests
Pas de test possible de bout en bout sans exposition (gateway/DNS). Un smoke-test du discovery endpoint via `kubectl port-forward` reste faisable une fois déployé.