### PR TITLE
fix(tls): resolve cert-manager HTTP-01 self-check via public DNS

### DIFF
--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -17,6 +17,14 @@ crds:
   # Keep CRDs on uninstall — ArgoCD prune must not wipe issued certs/orders.
   keep: true
 
+# The HTTP-01 self-check resolves the challenge host through cert-manager's own
+# recursive resolver. Cluster CoreDNS does not know *.kubequest.epitech.beer
+# (the records are public-only), so the self-check fails with "no such host"
+# even though Let's Encrypt resolves it fine from outside. Point the resolver at
+# public nameservers so the self-check matches what Let's Encrypt sees.
+dns01RecursiveNameserversOnly: true
+dns01RecursiveNameservers: "8.8.8.8:53,1.1.1.1:53"
+
 # Constrained cluster: single replica per component, hard resource limits.
 # cert-manager also lands on the control-plane, the node we keep from OOMing.
 replicaCount: 1

--- a/k8s/cert-manager/cert-manager.yaml
+++ b/k8s/cert-manager/cert-manager.yaml
@@ -13490,6 +13490,8 @@ spec:
           - --leader-election-namespace=kube-system
           - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.20.2
           - --max-concurrent-challenges=60
+          - --dns01-recursive-nameservers-only=true
+          - --dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53
           ports:
           - containerPort: 9402
             name: http-metrics


### PR DESCRIPTION
## Problem
The Argo CD certificate stayed `READY: False`. The HTTP-01 challenge was presented correctly, but cert-manager's **self-check** resolved the challenge host through cluster CoreDNS (`10.96.0.10:53`), which does not know `*.kubequest.epitech.beer` (public-only DNS) — failing with `no such host`. Let's Encrypt itself would have resolved it fine from outside.

## Fix
Point cert-manager's recursive resolver at public nameservers so the self-check matches what Let's Encrypt sees:
- `dns01RecursiveNameserversOnly: true`
- `dns01RecursiveNameservers: 8.8.8.8:53,1.1.1.1:53`

(Despite the `dns01` name, these flags drive the resolver used by the HTTP-01 self-check too.) Manifest regenerated from chart v1.20.2.