### PR TITLE
feat(tls): switch Argo CD to letsencrypt-prod, document HTTP-01 self-check

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -85,6 +85,6 @@ kubectl -n argocd get secret argocd-initial-admin-secret \
 Log in as user `admin`. (A `kubectl -n argocd port-forward svc/argocd-server
 8080:80` still works for local access if the Ingress is down.)
 
-> The Ingress starts on the `letsencrypt-staging` issuer (untrusted cert, used
-> to validate HTTP-01). Switch the `cert-manager.io/cluster-issuer` annotation
-> to `letsencrypt-prod` once staging issues cleanly.
+> TLS is issued by the `letsencrypt-prod` ClusterIssuer (HTTP-01). The chain was
+> first validated on `letsencrypt-staging`. See `k8s/cert-manager/README.md` for
+> the CoreDNS `hosts` entry that lets the HTTP-01 self-check resolve internally.

--- a/helm/cert-manager/values.yaml
+++ b/helm/cert-manager/values.yaml
@@ -17,13 +17,11 @@ crds:
   # Keep CRDs on uninstall — ArgoCD prune must not wipe issued certs/orders.
   keep: true
 
-# The HTTP-01 self-check resolves the challenge host through cert-manager's own
-# recursive resolver. Cluster CoreDNS does not know *.kubequest.epitech.beer
-# (the records are public-only), so the self-check fails with "no such host"
-# even though Let's Encrypt resolves it fine from outside. Point the resolver at
-# public nameservers so the self-check matches what Let's Encrypt sees.
-dns01RecursiveNameserversOnly: true
-dns01RecursiveNameservers: "8.8.8.8:53,1.1.1.1:53"
+# Note: the HTTP-01 self-check resolves the challenge host through the pod's
+# /etc/resolv.conf (cluster CoreDNS), NOT through the dns01 recursive-nameserver
+# flags — those only affect the DNS-01 self-check. CoreDNS is given a `hosts`
+# entry mapping argocd.kubequest.epitech.beer to the control-plane Elastic IP so
+# the self-check resolves internally. See k8s/argocd/ingress.yaml.
 
 # Constrained cluster: single replica per component, hard resource limits.
 # cert-manager also lands on the control-plane, the node we keep from OOMing.

--- a/k8s/argocd/ingress.yaml
+++ b/k8s/argocd/ingress.yaml
@@ -4,16 +4,18 @@
 # once; otherwise the server's own TLS plus the Ingress TLS double up and cause
 # redirect loops. See argocd/install/values.yaml (configs.params).
 #
-# Starts on the staging issuer to validate HTTP-01 end to end. Once a staging
-# cert is issued, switch the cert-manager.io/cluster-issuer annotation to
-# letsencrypt-prod and delete the staging secret to force a prod re-issue.
+# Uses the production Let's Encrypt issuer. The HTTP-01 chain was first
+# validated on letsencrypt-staging; the cluster CoreDNS resolves the host to the
+# control-plane Elastic IP (hosts block in the coredns ConfigMap) so the
+# cert-manager HTTP-01 self-check passes — the dns01 recursive-nameserver flags
+# do not affect the HTTP-01 self-check.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server
   namespace: argocd
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-staging
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
 spec:
   ingressClassName: nginx

--- a/k8s/cert-manager/README.md
+++ b/k8s/cert-manager/README.md
@@ -45,6 +45,28 @@ production rate limit, then switch the Ingress
 `cert-manager.io/cluster-issuer` annotation to `letsencrypt-prod` and delete the
 old secret to force a prod re-issue.
 
+### HTTP-01 self-check and CoreDNS
+Before reaching out to Let's Encrypt, cert-manager runs a **self-check** that
+fetches the challenge URL itself. This self-check resolves the host through the
+pod's `/etc/resolv.conf` — i.e. cluster **CoreDNS** — not through the
+`dns01-recursive-nameservers` flags (those only apply to the DNS-01 self-check).
+
+CoreDNS forwards unknown names to the node resolver, which does not resolve
+`argocd.kubequest.epitech.beer` internally, so the self-check failed with
+`no such host` while the public DNS resolved fine. Fix: a `hosts` block in the
+`coredns` ConfigMap (`kube-system`) maps the host to the control-plane Elastic
+IP:
+
+```
+hosts {
+   18.158.153.65 argocd.kubequest.epitech.beer
+   fallthrough
+}
+```
+Applied live (CoreDNS is managed by kubeadm, not GitOps) and reloaded with
+`kubectl -n kube-system rollout restart deploy/coredns`. Add a line per new host
+exposed under this domain.
+
 ## Deployment
 GitOps via three Applications under `argocd/apps`, ordered by sync-wave so the
 webhook is ready before any custom resource is admitted:

--- a/k8s/cert-manager/cert-manager.yaml
+++ b/k8s/cert-manager/cert-manager.yaml
@@ -13490,8 +13490,6 @@ spec:
           - --leader-election-namespace=kube-system
           - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.20.2
           - --max-concurrent-challenges=60
-          - --dns01-recursive-nameservers-only=true
-          - --dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53
           ports:
           - containerPort: 9402
             name: http-metrics


### PR DESCRIPTION
## Summary
The staging HTTP-01 chain validated end to end (cert issued, HTTPS reachable), so switch the Argo CD Ingress to the **production** Let's Encrypt issuer.

## What actually fixed the self-check
The `dns01-recursive-nameservers` flags added in #39 did **not** fix the failing HTTP-01 self-check — those flags only affect the **DNS-01** self-check. The HTTP-01 self-check resolves the challenge host through the pod's `/etc/resolv.conf` (cluster **CoreDNS**), which did not resolve `argocd.kubequest.epitech.beer` internally.

The real fix: a `hosts` block in the `coredns` ConfigMap mapping the host to the control-plane Elastic IP. CoreDNS is kubeadm-managed (not GitOps), so it is applied live and documented in `k8s/cert-manager/README.md`.

## Changes
- `k8s/argocd/ingress.yaml` — issuer annotation `letsencrypt-staging` → `letsencrypt-prod`.
- `helm/cert-manager/values.yaml` + rendered manifest — drop the ineffective dns01 flags, document the real mechanism.
- READMEs — document the CoreDNS `hosts` entry and the prod switch.

## Verified
- Staging cert issued, challenge `valid`, HTTPS returned 307 (Argo CD redirect, no TLS loop).
- Prod re-issue follows after merge + secret deletion.