### PR TITLE
feat(helm): package sample-app as a Helm chart

### DIFF
--- a/helm/sample-app/BEST_PRACTICES.md
+++ b/helm/sample-app/BEST_PRACTICES.md
@@ -32,6 +32,20 @@ Adjust in `values.yaml` to match the target node capacity.
 - **readinessProbe** — HTTP GET `/` on port 80, starts after 10 s, checked every 5 s. Prevents traffic from reaching pods that are not ready.
 - **livenessProbe** — HTTP GET `/` on port 80, starts after 30 s, checked every 10 s. Restarts pods that become unresponsive.
 
+## Security context
+
+The container runs with `runAsNonRoot: false`. This is a deliberate exception: the
+Apache process in the image binds port 80, a privileged port that requires root.
+`fsGroup: 33` (`www-data`) is set so mounted volumes remain group-accessible.
+
+> If the workload is later switched to a non-privileged listening port (> 1024),
+> set `runAsNonRoot: true` to restore the recommended hardening.
+
 ## Secrets
 
 Sensitive values (`APP_KEY`, `DB_PASSWORD`) are stored in a Kubernetes `Secret` and injected via `secretKeyRef`. They are **never** hardcoded in `values.yaml` — both are required at install time via `--set`.
+
+> Note: values passed with `--set` are persisted in the Helm release (visible via
+> `helm get values`). For production, prefer an externally-managed `Secret`
+> (e.g. External Secrets Operator) and reference it instead of supplying the
+> values to Helm directly.

--- a/helm/sample-app/BEST_PRACTICES.md
+++ b/helm/sample-app/BEST_PRACTICES.md
@@ -1,0 +1,37 @@
+# Kubernetes Best Practices — sample-app
+
+## Labels
+
+All resources use the standard `app.kubernetes.io/*` label set:
+
+| Label | Value |
+|---|---|
+| `app.kubernetes.io/name` | `sample-app` |
+| `app.kubernetes.io/instance` | release name |
+| `app.kubernetes.io/version` | app version from `Chart.yaml` |
+| `app.kubernetes.io/managed-by` | `Helm` |
+
+## Replicas & anti-affinity
+
+`replicaCount` defaults to **2** to ensure availability.  
+A `podAntiAffinity` rule (`preferredDuringSchedulingIgnoredDuringExecution`) spreads pods across worker nodes using `kubernetes.io/hostname` as topology key.
+
+## Resource limits & requests
+
+Every container declares `resources.requests` and `resources.limits`:
+
+| | CPU | Memory |
+|---|---|---|
+| requests | 100m | 128Mi |
+| limits | 500m | 512Mi |
+
+Adjust in `values.yaml` to match the target node capacity.
+
+## Probes
+
+- **readinessProbe** — HTTP GET `/` on port 80, starts after 10 s, checked every 5 s. Prevents traffic from reaching pods that are not ready.
+- **livenessProbe** — HTTP GET `/` on port 80, starts after 30 s, checked every 10 s. Restarts pods that become unresponsive.
+
+## Secrets
+
+Sensitive values (`APP_KEY`, `DB_PASSWORD`) are stored in a Kubernetes `Secret` and injected via `secretKeyRef`. They are **never** hardcoded in `values.yaml` — both are required at install time via `--set`.

--- a/helm/sample-app/Chart.yaml
+++ b/helm/sample-app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: sample-app
+description: Laravel PHP application for KubeQuest
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/sample-app/templates/NOTES.txt
+++ b/helm/sample-app/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Application deployed successfully.
+
+Access the app at: http://{{ .Values.ingress.host }}
+(make sure your DNS or /etc/hosts points {{ .Values.ingress.host }} to the ingress node IP)
+
+To install with required secrets:
+  helm install sample-app ./helm/sample-app \
+    --set app.key="$(php artisan key:generate --show)" \
+    --set db.password="<your-db-password>"

--- a/helm/sample-app/templates/_helpers.tpl
+++ b/helm/sample-app/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{- define "sample-app.name" -}}
+{{- .Chart.Name }}
+{{- end }}
+
+{{- define "sample-app.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "sample-app.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ include "sample-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "sample-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sample-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/sample-app/templates/deployment.yaml
+++ b/helm/sample-app/templates/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sample-app.fullname" . }}
+  labels:
+    {{- include "sample-app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sample-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "sample-app.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: false  # Apache requires root to bind port 80
+        fsGroup: 33          # www-data
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: APP_ENV
+              value: {{ .Values.app.env | quote }}
+            - name: APP_DEBUG
+              value: {{ .Values.app.debug | quote }}
+            - name: APP_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sample-app.fullname" . }}
+                  key: APP_KEY
+            - name: DB_CONNECTION
+              value: mysql
+            - name: DB_HOST
+              value: {{ .Values.db.host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.db.port | quote }}
+            - name: DB_DATABASE
+              value: {{ .Values.db.database | quote }}
+            - name: DB_USERNAME
+              value: {{ .Values.db.username | quote }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sample-app.fullname" . }}
+                  key: DB_PASSWORD
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}

--- a/helm/sample-app/templates/deployment.yaml
+++ b/helm/sample-app/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroup: 33          # www-data
       containers:
         - name: app
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/helm/sample-app/templates/ingress.yaml
+++ b/helm/sample-app/templates/ingress.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sample-app.fullname" . }}
+  labels:
+    {{- include "sample-app.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "sample-app.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/helm/sample-app/templates/secret.yaml
+++ b/helm/sample-app/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sample-app.fullname" . }}
+  labels:
+    {{- include "sample-app.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  APP_KEY: {{ required "app.key is required" .Values.app.key | quote }}
+  DB_PASSWORD: {{ required "db.password is required" .Values.db.password | quote }}

--- a/helm/sample-app/templates/service.yaml
+++ b/helm/sample-app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sample-app.fullname" . }}
+  labels:
+    {{- include "sample-app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "sample-app.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/helm/sample-app/values.yaml
+++ b/helm/sample-app/values.yaml
@@ -1,0 +1,53 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/t-clo-902-kubequest/sample-app
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: nginx
+  host: app.kubequest.local
+  path: /
+  pathType: Prefix
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+app:
+  env: production
+  debug: "false"
+  # APP_KEY must be provided at install time, never committed
+  key: ""
+
+db:
+  host: mysql
+  port: 3306
+  database: app_database
+  username: app_user
+  # password provided via --set db.password or external Secret
+  password: ""
+
+nodeSelector: {}
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: sample-app
+          topologyKey: kubernetes.io/hostname
+
+tolerations: []

--- a/helm/sample-app/values.yaml
+++ b/helm/sample-app/values.yaml
@@ -1,10 +1,12 @@
 replicaCount: 2
 
 image:
-  repository: ghcr.io/t-clo-902-kubequest/sample-app
-  # TODO: pin to a semver tag once the CI pipeline builds the image from
-  # conventional commits (semantic-release). "latest" is not reproducible.
-  tag: "latest"
+  # Path published by .github/workflows/sample-app-build.yml
+  # (${{ github.repository }}/sample-app, lowercased by GHCR).
+  repository: ghcr.io/t-clo-902-kubequest/kubequest/sample-app
+  # Empty by default: the chart falls back to Chart.appVersion, which the CI
+  # pipeline publishes as a semver tag. Override per-release with --set if needed.
+  tag: ""
   pullPolicy: IfNotPresent
 
 service:

--- a/helm/sample-app/values.yaml
+++ b/helm/sample-app/values.yaml
@@ -2,6 +2,8 @@ replicaCount: 2
 
 image:
   repository: ghcr.io/t-clo-902-kubequest/sample-app
+  # TODO: pin to a semver tag once the CI pipeline builds the image from
+  # conventional commits (semantic-release). "latest" is not reproducible.
   tag: "latest"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Closes #16

## Summary
- Convertit le `docker-compose.yaml` de la sample-app en Helm chart sous `helm/sample-app/`
- Chart paramétrable via `values.yaml` (image, replicas, resources, DB, ingress)
- Génère les ressources K8s : Deployment, Service, Ingress, Secret

## Test plan
- [x] `helm lint` passe sans erreur
- [x] `helm template` génère des manifests valides
- [x] Déployé sur le cluster AWS (Deployment, Service, Ingress, Secret bien créés)
- [ ] Test complet avec l'image applicative (dépend de l'issue #19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)