### PR TITLE
feat: deploy headlamp dashboard via gitops

### DIFF
--- a/argocd/apps/headlamp/application.yaml
+++ b/argocd/apps/headlamp/application.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: headlamp
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/T-CLO-902-KubeQuest/KubeQuest.git
+    targetRevision: main
+    path: k8s/headlamp
+    directory:
+      include: "{headlamp.yaml,ingress.yaml}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: headlamp
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/helm/headlamp/values.yaml
+++ b/helm/headlamp/values.yaml
@@ -1,0 +1,60 @@
+# Headlamp values used to render k8s/headlamp/headlamp.yaml.
+# Regenerate the manifest with:
+#   helm repo add headlamp https://kubernetes-sigs.github.io/headlamp/
+#   helm repo update headlamp
+#   helm template headlamp headlamp/headlamp \
+#     --version <CHART_VERSION> \
+#     --namespace headlamp \
+#     --values helm/headlamp/values.yaml \
+#     > k8s/headlamp/headlamp.yaml
+#
+# Pinned chart version: 0.43.0 (app version 0.43.0).
+#
+# Headlamp is the cluster dashboard (Issue #9). Unlike ingress-nginx it has no
+# special networking needs: it sits *behind* the ingress as a plain HTTP app,
+# so no hostNetwork and no control-plane pinning here.
+
+# Single replica: a dashboard has no HA requirement on this cluster.
+replicaCount: 1
+
+config:
+  # Headlamp talks to the API from inside the cluster (uses its own
+  # ServiceAccount to reach kube-apiserver). This is the in-cluster mode.
+  inCluster: true
+
+  # Do NOT let Headlamp auto-authenticate with its own ServiceAccount token.
+  # Kept false so the UI shows a login screen and each session runs with the
+  # permissions of the *token the user pastes in* — not a blanket pod identity.
+  unsafeUseServiceAccountToken: false
+
+# The chart creates a ServiceAccount for the pod and binds it to a ClusterRole.
+serviceAccount:
+  create: true
+clusterRoleBinding:
+  create: true
+  # Read-only by default (safe). The bound role governs the pod identity; with
+  # unsafeUseServiceAccountToken=false the *login token* is what actually drives
+  # what a user can do in the UI. Switch to "cluster-admin" if you want the
+  # dashboard itself to be able to mutate resources.
+  clusterRoleName: view
+
+# The Service is internal only; traffic reaches Headlamp through the Ingress
+# (see k8s/headlamp/ingress.yaml), so ClusterIP — never LoadBalancer/NodePort.
+service:
+  type: ClusterIP
+  port: 80
+
+# Ingress is declared as a standalone manifest (like Argo CD's, in
+# k8s/argocd/ingress.yaml) so TLS via cert-manager lives next to it and stays a
+# reviewable diff. Keep the chart's own Ingress off to avoid two sources.
+ingress:
+  enabled: false
+
+# Constrained cluster: cap the dashboard rather than let it burst.
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi

--- a/k8s/headlamp/README.md
+++ b/k8s/headlamp/README.md
@@ -1,0 +1,63 @@
+# Headlamp Dashboard
+
+## Overview
+[Headlamp](https://headlamp.dev/) is the cluster's web dashboard (Issue #9): a
+read-only window onto workloads, nodes, events and logs, served as a plain HTTP
+app behind the ingress. It talks to the kube-apiserver from inside the cluster
+(`config.inCluster`) and authenticates each session with a bearer token the user
+provides — so what a user can see/do is bounded by *their* token, not a blanket
+dashboard identity.
+
+## Design: vendored manifest
+Like the Cilium CNI, Argo CD and ingress-nginx, Headlamp is installed from a
+manifest checked into the repo (`k8s/headlamp/headlamp.yaml`), rendered with
+`helm template` — never `helm install` (no Helm release state on the cluster).
+Every change is a reviewable diff alongside its source values
+(`helm/headlamp/values.yaml`).
+
+### Regenerating the manifest
+```sh
+helm repo add headlamp https://kubernetes-sigs.github.io/headlamp/
+helm repo update headlamp
+helm template headlamp headlamp/headlamp \
+  --version <CHART_VERSION> \
+  --namespace headlamp \
+  --values helm/headlamp/values.yaml \
+  > k8s/headlamp/headlamp.yaml
+```
+Pinned chart version: **0.43.0** (app version 0.43.0). Bump it here and in the
+command above, then commit the regenerated manifest with the values change.
+
+## Exposure & TLS
+Headlamp has no special networking needs — no `hostNetwork`, no control-plane
+pinning. The `Service` stays `ClusterIP`; real traffic reaches it through a
+standalone `Ingress` (`k8s/headlamp/ingress.yaml`) on the `nginx` IngressClass,
+with TLS issued by cert-manager. As with Argo CD, the Ingress starts on the
+`letsencrypt-staging` issuer to validate HTTP-01 end to end, then switches to
+`letsencrypt-prod` once a staging cert is issued.
+
+Target host: **https://headlamp.kubequest.epitech.beer**
+
+### Resource limits
+The cluster is resource-constrained, so the dashboard is capped
+(`requests` 50m/64Mi, `limits` 200m/128Mi) rather than left to burst.
+
+## Authentication & RBAC
+The chart creates a `ServiceAccount` and a `ClusterRoleBinding` for the pod. It
+is bound to the built-in **`view`** ClusterRole (read-only) — see
+`clusterRoleName` in `helm/headlamp/values.yaml`. Switch it to `cluster-admin`
+only if the dashboard itself must mutate resources.
+
+`unsafeUseServiceAccountToken` is **false**: the UI shows a login screen and runs
+each session with the permissions of the token the user pastes. Mint one with:
+```sh
+kubectl -n headlamp create token headlamp
+```
+The session's effective permissions are the intersection of that token's RBAC
+and the dashboard's reachability — a token from a more privileged ServiceAccount
+grants more in the UI.
+
+## Deployment
+Managed by GitOps: the `Application` at `argocd/apps/headlamp/application.yaml`
+is picked up by the root app-of-apps and synced automatically. No manual
+`kubectl apply`.

--- a/k8s/headlamp/headlamp.yaml
+++ b/k8s/headlamp/headlamp.yaml
@@ -1,0 +1,147 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.43.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.43.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: headlamp
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.43.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.43.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: headlamp
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.43.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.43.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.43.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.43.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.43.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/k8s/headlamp/ingress.yaml
+++ b/k8s/headlamp/ingress.yaml
@@ -1,0 +1,32 @@
+# Ingress exposing the Headlamp dashboard at headlamp.kubequest.epitech.beer.
+#
+# Headlamp serves plain HTTP on its Service (port 80), so no backend-protocol
+# annotation is needed — HTTP is ingress-nginx's default.
+#
+# Starts on the staging issuer to validate HTTP-01 end to end. Once a staging
+# cert is issued, switch the cert-manager.io/cluster-issuer annotation to
+# letsencrypt-prod and delete the staging secret to force a prod re-issue.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: headlamp
+  namespace: headlamp
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - headlamp.kubequest.epitech.beer
+      secretName: headlamp-tls
+  rules:
+    - host: headlamp.kubequest.epitech.beer
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: headlamp
+                port:
+                  number: 80


### PR DESCRIPTION
## Résumé
Déploie le dashboard **Headlamp** (issue #9 — fournir un dashboard de gestion du cluster) en suivant le même patron GitOps « vendored manifest » que Cilium, Argo CD et ingress-nginx.

Closes #9

## Contenu
- `helm/headlamp/values.yaml` — values source (chart `headlamp` 0.43.0) : replica unique, `ClusterIP`, ressources plafonnées, Ingress du chart désactivé.
- `k8s/headlamp/headlamp.yaml` — manifeste rendu via `helm template` (jamais `helm install`).
- `k8s/headlamp/ingress.yaml` — Ingress `nginx` exposant `headlamp.kubequest.epitech.beer`, TLS cert-manager (issuer `letsencrypt-staging` d'abord).
- `argocd/apps/headlamp/application.yaml` — `Application` synchronisée par le root app-of-apps (namespace `headlamp`, `CreateNamespace=true`).
- `k8s/headlamp/README.md` — doc des choix + commande de régénération.

## Décisions
- **RBAC en lecture seule** : le `ClusterRoleBinding` du chart pointe vers la ClusterRole `view`. À basculer sur `cluster-admin` (une ligne dans les values) si besoin d'agir depuis l'UI.
- **`unsafeUseServiceAccountToken: false`** : l'UI demande un token au login, chaque session hérite des droits de ce token.
- Pas de `ServerSideApply` (pas de gros CRD, contrairement à ingress-nginx) ni d'annotation `backend-protocol` (Headlamp sert du HTTP, qui est le défaut).

## À faire après merge
1. Vérifier que `headlamp.kubequest.epitech.beer` pointe vers l'IP de l'ingress (nécessaire au challenge HTTP-01).
2. Une fois le certif staging émis, basculer l'annotation sur `letsencrypt-prod` et supprimer le secret `headlamp-tls`.