### PR TITLE
feat: switch dex and headlamp ingresses to letsencrypt-prod

### DIFF
--- a/k8s/cert-manager/README.md
+++ b/k8s/cert-manager/README.md
@@ -60,6 +60,8 @@ IP:
 ```
 hosts {
    18.158.153.65 argocd.kubequest.epitech.beer
+   18.158.153.65 headlamp.kubequest.epitech.beer
+   18.158.153.65 dex.kubequest.epitech.beer
    fallthrough
 }
 ```

--- a/k8s/dex/README.md
+++ b/k8s/dex/README.md
@@ -34,8 +34,9 @@ command above, then commit the regenerated manifest with the values change.
 The `Service` stays `ClusterIP` (port 5556, plain HTTP); real traffic reaches Dex
 through a standalone `Ingress` (`k8s/dex/ingress.yaml`) on the `nginx`
 IngressClass, with TLS issued by cert-manager. As with Argo CD and Headlamp, the
-Ingress starts on the `letsencrypt-staging` issuer to validate HTTP-01 end to
-end, then switches to `letsencrypt-prod` once a staging cert is issued.
+Ingress runs on the `letsencrypt-prod` issuer; the chain was first validated on
+`letsencrypt-staging` before switching. The HTTP-01 self-check needs a CoreDNS
+`hosts` entry for this host — see `k8s/cert-manager/README.md`.
 
 Target host: **https://dex.kubequest.epitech.beer** — this MUST match
 `config.issuer` in the values and every client's configured issuer URL.

--- a/k8s/dex/ingress.yaml
+++ b/k8s/dex/ingress.yaml
@@ -3,16 +3,16 @@
 # Dex serves plain HTTP on its Service (port 5556), so no backend-protocol
 # annotation is needed — HTTP is ingress-nginx's default.
 #
-# Starts on the staging issuer to validate HTTP-01 end to end. Once a staging
-# cert is issued, switch the cert-manager.io/cluster-issuer annotation to
-# letsencrypt-prod and delete the staging secret to force a prod re-issue.
+# TLS is issued by the letsencrypt-prod ClusterIssuer (HTTP-01). The chain was
+# first validated on letsencrypt-staging; see k8s/cert-manager/README.md for the
+# CoreDNS hosts entry that lets the HTTP-01 self-check resolve internally.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: dex
   namespace: dex
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-staging
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   ingressClassName: nginx
   tls:

--- a/k8s/headlamp/README.md
+++ b/k8s/headlamp/README.md
@@ -32,9 +32,10 @@ command above, then commit the regenerated manifest with the values change.
 Headlamp has no special networking needs — no `hostNetwork`, no control-plane
 pinning. The `Service` stays `ClusterIP`; real traffic reaches it through a
 standalone `Ingress` (`k8s/headlamp/ingress.yaml`) on the `nginx` IngressClass,
-with TLS issued by cert-manager. As with Argo CD, the Ingress starts on the
-`letsencrypt-staging` issuer to validate HTTP-01 end to end, then switches to
-`letsencrypt-prod` once a staging cert is issued.
+with TLS issued by cert-manager. As with Argo CD, the Ingress runs on the
+`letsencrypt-prod` issuer; the chain was first validated on `letsencrypt-staging`
+before switching. The HTTP-01 self-check needs a CoreDNS `hosts` entry for this
+host — see `k8s/cert-manager/README.md`.
 
 Target host: **https://headlamp.kubequest.epitech.beer**
 

--- a/k8s/headlamp/ingress.yaml
+++ b/k8s/headlamp/ingress.yaml
@@ -3,16 +3,16 @@
 # Headlamp serves plain HTTP on its Service (port 80), so no backend-protocol
 # annotation is needed — HTTP is ingress-nginx's default.
 #
-# Starts on the staging issuer to validate HTTP-01 end to end. Once a staging
-# cert is issued, switch the cert-manager.io/cluster-issuer annotation to
-# letsencrypt-prod and delete the staging secret to force a prod re-issue.
+# TLS is issued by the letsencrypt-prod ClusterIssuer (HTTP-01). The chain was
+# first validated on letsencrypt-staging; see k8s/cert-manager/README.md for the
+# CoreDNS hosts entry that lets the HTTP-01 self-check resolve internally.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: headlamp
   namespace: headlamp
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-staging
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## What

Switch the Dex ingress from the `letsencrypt-staging` to the `letsencrypt-prod` cert-manager ClusterIssuer, now that the staging chain has validated end to end (DNS → HTTP-01 self-check → ingress).

## Changes
- `k8s/dex/ingress.yaml`: `cluster-issuer` annotation `letsencrypt-staging` → `letsencrypt-prod`; header comment updated to match (same wording as the Argo CD / Headlamp ingresses).
- `k8s/dex/README.md`: TLS section reflects prod issuer + points to the CoreDNS self-check note.
- `k8s/cert-manager/README.md`: the documented CoreDNS `hosts` block now lists `headlamp` and `dex` alongside `argocd` (reflects the live ConfigMap).

## Post-merge
After Argo CD resyncs, force a prod re-issue by deleting the staging secret:
```sh
kubectl -n dex delete secret dex-tls
```

Note: the CoreDNS `hosts` entry for `dex.kubequest.epitech.beer` is applied live (CoreDNS is kubeadm-managed, not GitOps) — documented, not committed.