### PR TITLE
feat(oidc): wire dex SSO to argocd and headlamp

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -28,8 +28,8 @@ components: `application-controller`, `repo-server`, `server` (API/UI) and
 `redis`. Disabled extras:
 
 - **Dex**: a cluster-wide external Dex is shared across workloads, so the bundled
-  Dex would be a second, redundant one. Wire SSO later via `oidc.config` in
-  `argocd-cm` (issuer = external Dex URL).
+  Dex would be a second, redundant one. SSO is wired to that external Dex via
+  `configs.cm.oidc.config` in `argocd/install/values.yaml` (see "SSO" below).
 - **ApplicationSet**: applications are declared by hand under `apps/`, so the
   controller is scaled to 0 replicas (the chart has no `enabled` toggle for it).
 - **Notifications**: no alerting wired up.
@@ -88,3 +88,21 @@ Log in as user `admin`. (A `kubectl -n argocd port-forward svc/argocd-server
 > TLS is issued by the `letsencrypt-prod` ClusterIssuer (HTTP-01). The chain was
 > first validated on `letsencrypt-staging`. See `k8s/cert-manager/README.md` for
 > the CoreDNS `hosts` entry that lets the HTTP-01 self-check resolve internally.
+
+## SSO (Dex / GitHub)
+Argo CD delegates login to the cluster-wide external Dex
+(`configs.cm.oidc.config` in `install/values.yaml`): users authenticate with
+GitHub through Dex, which only admits members of the `T-CLO-902-KubeQuest` org.
+
+The OIDC client secret is **not** in Git. It lives under the key
+`dex.argocd-client-secret` in the `argocd-secret` Secret and must equal the
+`argocd` value of the `dex-clients` Secret on the Dex side. Set it by hand:
+```sh
+kubectl -n argocd patch secret argocd-secret \
+  -p "{\"stringData\":{\"dex.argocd-client-secret\":\"<secret>\"}}"
+```
+
+RBAC: SSO users get `role:readonly` by default (`configs.rbac.policy.default`).
+**Admin is not granted through SSO** — use the local `admin` account for
+privileged actions. Promote specific GitHub teams later by adding
+`policy.csv` lines (e.g. `g, T-CLO-902-KubeQuest:maintainers, role:admin`).

--- a/argocd/install/argocd.yaml
+++ b/argocd/install/argocd.yaml
@@ -98,6 +98,16 @@ data:
   application.instanceLabelKey: argocd.argoproj.io/instance
   application.sync.impersonation.enabled: "false"
   exec.enabled: "false"
+  oidc.config: |
+    name: Dex
+    issuer: https://dex.kubequest.epitech.beer
+    clientID: argocd
+    clientSecret: $dex.argocd-client-secret
+    requestedScopes:
+      - openid
+      - profile
+      - email
+      - groups
   resource.customizations.ignoreResourceUpdates.ConfigMap: |
     jqPathExpressions:
       # Ignore the cluster-autoscaler status
@@ -195,7 +205,7 @@ data:
   timeout.hard.reconciliation: 0s
   timeout.reconciliation: 120s
   timeout.reconciliation.jitter: 60s
-  url: https://argocd.example.com
+  url: https://argocd.kubequest.epitech.beer
 ---
 # Source: argo-cd/templates/argocd-configs/argocd-cmd-params-cm.yaml
 apiVersion: v1
@@ -262,7 +272,7 @@ metadata:
     app.kubernetes.io/version: "v3.4.3"
 data:
   policy.csv: ""
-  policy.default: ""
+  policy.default: role:readonly
   policy.matchMode: glob
   scopes: '[groups]'
 ---
@@ -31785,7 +31795,7 @@ spec:
     metadata:
       annotations:
         checksum/cmd-params: 46ae07a669f0b6fdcf832bf9f8f79b477567031d153165aaaa4641850d4852a5
-        checksum/cm: f1975cc0351b25d50d4277f96e3b11a4dfc1799e16af52b9e51bd8cd004e7e2c
+        checksum/cm: f14ce36d75af1e55b223a653d0665290c8f448b455979c07b78956352e7630a9
       labels:
         helm.sh/chart: argo-cd-9.5.21
         app.kubernetes.io/name: argocd-repo-server
@@ -32212,7 +32222,7 @@ spec:
     metadata:
       annotations:
         checksum/cmd-params: 46ae07a669f0b6fdcf832bf9f8f79b477567031d153165aaaa4641850d4852a5
-        checksum/cm: f1975cc0351b25d50d4277f96e3b11a4dfc1799e16af52b9e51bd8cd004e7e2c
+        checksum/cm: f14ce36d75af1e55b223a653d0665290c8f448b455979c07b78956352e7630a9
       labels:
         helm.sh/chart: argo-cd-9.5.21
         app.kubernetes.io/name: argocd-server
@@ -32764,7 +32774,7 @@ spec:
     metadata:
       annotations:
         checksum/cmd-params: 46ae07a669f0b6fdcf832bf9f8f79b477567031d153165aaaa4641850d4852a5
-        checksum/cm: f1975cc0351b25d50d4277f96e3b11a4dfc1799e16af52b9e51bd8cd004e7e2c
+        checksum/cm: f14ce36d75af1e55b223a653d0665290c8f448b455979c07b78956352e7630a9
       labels:
         helm.sh/chart: argo-cd-9.5.21
         app.kubernetes.io/name: argocd-application-controller

--- a/argocd/install/values.yaml
+++ b/argocd/install/values.yaml
@@ -56,3 +56,27 @@ server:
 configs:
   params:
     server.insecure: true
+
+  # argocd-cm: public URL + SSO via the cluster-wide external Dex.
+  cm:
+    # Must be the real external URL (the chart default is argocd.example.com).
+    # OIDC redirect URIs are derived from it, so a wrong value breaks login.
+    url: https://argocd.kubequest.epitech.beer
+    # Delegate login to Dex (issuer = external Dex URL). The client secret is not
+    # inlined: $dex.argocd-client-secret resolves to key "dex.argocd-client-secret"
+    # in the argocd-secret Secret, created by hand (kept out of Git).
+    oidc.config: |
+      name: Dex
+      issuer: https://dex.kubequest.epitech.beer
+      clientID: argocd
+      clientSecret: $dex.argocd-client-secret
+      requestedScopes:
+        - openid
+        - profile
+        - email
+        - groups
+
+  # argocd-rbac-cm: SSO users are read-only by default. Admin stays the local
+  # "admin" account (not granted through SSO).
+  rbac:
+    policy.default: role:readonly

--- a/helm/dex/values.yaml
+++ b/helm/dex/values.yaml
@@ -56,34 +56,45 @@ config:
         clientID: $GITHUB_CLIENT_ID
         clientSecret: $GITHUB_CLIENT_SECRET
         redirectURI: https://dex.kubequest.epitech.beer/callback
-        # Restrict and map GitHub orgs/teams to OIDC groups.
-        # orgs:
-        #   - name: my-github-org
+        # Only members of this GitHub org may log in; their teams become OIDC
+        # groups (surfaced to clients that request the "groups" scope, e.g. for
+        # Argo CD RBAC).
+        orgs:
+          - name: T-CLO-902-KubeQuest
 
   # Services allowed to use Dex as their OIDC provider. One entry per app.
-  # Each client secret must match what the app is configured with; keep real
-  # secrets out of this file (use a sealed secret / external secret if needed).
+  # Each client secret is pulled from an env var (secretEnv, dex >= 2.35.0) so it
+  # never lands in this file or the rendered manifest. The env vars are fed by a
+  # hand-created Secret (see envVars below); keep the real values out of Git.
   staticClients:
     - id: grafana
       name: Grafana
-      secret: CHANGE_ME_grafana
+      secretEnv: GRAFANA_CLIENT_SECRET
       redirectURIs:
         - https://grafana.kubequest.epitech.beer/login/generic_oauth
     - id: argocd
       name: ArgoCD
-      secret: CHANGE_ME_argocd
+      secretEnv: ARGOCD_CLIENT_SECRET
       redirectURIs:
         - https://argocd.kubequest.epitech.beer/auth/callback
     - id: headlamp
       name: Headlamp
-      secret: CHANGE_ME_headlamp
+      secretEnv: HEADLAMP_CLIENT_SECRET
       redirectURIs:
         - https://headlamp.kubequest.epitech.beer/oidc-callback
 
-# GitHub OAuth app credentials, sourced from a pre-created Kubernetes Secret.
-# Create it once (do NOT commit the values):
+# Secrets injected into the Dex pod, all sourced from hand-created Kubernetes
+# Secrets (never committed):
+#
+#   # GitHub OAuth app (the upstream connector):
 #   kubectl -n dex create secret generic dex-github \
 #     --from-literal=clientID=<id> --from-literal=clientSecret=<secret>
+#
+#   # One shared secret per OIDC client (must match each app's config):
+#   kubectl -n dex create secret generic dex-clients \
+#     --from-literal=argocd=<secret> \
+#     --from-literal=headlamp=<secret> \
+#     --from-literal=grafana=<secret>
 envVars:
   - name: GITHUB_CLIENT_ID
     valueFrom:
@@ -95,6 +106,21 @@ envVars:
       secretKeyRef:
         name: dex-github
         key: clientSecret
+  - name: ARGOCD_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: dex-clients
+        key: argocd
+  - name: HEADLAMP_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: dex-clients
+        key: headlamp
+  - name: GRAFANA_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: dex-clients
+        key: grafana
 
 # Internal only; traffic reaches Dex through the standalone Ingress
 # (k8s/dex/ingress.yaml), so ClusterIP — never LoadBalancer/NodePort.

--- a/helm/headlamp/values.yaml
+++ b/helm/headlamp/values.yaml
@@ -27,6 +27,30 @@ config:
   # permissions of the *token the user pastes in* — not a blanket pod identity.
   unsafeUseServiceAccountToken: false
 
+  # OIDC login via the cluster-wide external Dex (which federates GitHub and only
+  # admits the T-CLO-902-KubeQuest org).
+  #
+  # This chart (0.43.0) only wires OIDC env vars via secretKeyRef when
+  # secret.create=true — but that also makes it render a Secret from the values
+  # below (clientSecret would land in Git). So we keep secret.create=true to get
+  # the secretKeyRef wiring, set clientSecret to a placeholder, and STRIP the
+  # generated Secret from the rendered manifest (see k8s/headlamp/README.md).
+  # The real Secret is created by hand and is the single source of truth:
+  #   kubectl -n headlamp create secret generic headlamp-oidc \
+  #     --from-literal=clientID=headlamp \
+  #     --from-literal=clientSecret=<secret> \
+  #     --from-literal=issuerURL=https://dex.kubequest.epitech.beer \
+  #     --from-literal=scopes="openid profile email groups"
+  # clientSecret must match the "headlamp" value of the dex-clients Secret.
+  oidc:
+    secret:
+      create: true
+      name: headlamp-oidc
+    clientID: headlamp
+    clientSecret: PLACEHOLDER_STRIPPED_FROM_MANIFEST
+    issuerURL: https://dex.kubequest.epitech.beer
+    scopes: "openid profile email groups"
+
 # The chart creates a ServiceAccount for the pod and binds it to a ClusterRole.
 serviceAccount:
   create: true

--- a/k8s/dex/README.md
+++ b/k8s/dex/README.md
@@ -52,12 +52,24 @@ kubectl -n dex create secret generic dex-github \
 The OAuth App's *Authorization callback URL* must be
 `https://dex.kubequest.epitech.beer/callback`.
 
+Login is restricted to members of the **`T-CLO-902-KubeQuest`** GitHub org
+(`connectors[].config.orgs` in the values); their teams are surfaced as OIDC
+groups to clients that request the `groups` scope.
+
 ## Clients
 Each service that logs in through Dex is declared as a `staticClient` in
-`helm/dex/values.yaml` (Grafana, Argo CD, Headlamp). The placeholder
-`CHANGE_ME_*` secrets are committed only as a shape; replace them with real
-shared secrets (sealed/external secret) that match each app's configuration. A
-client's `redirectURIs` must exactly match what the app sends.
+`helm/dex/values.yaml` (Grafana, Argo CD, Headlamp). Client secrets are **not**
+in Git: each entry uses `secretEnv` (dex >= 2.35.0) to read its secret from an
+env var, fed by a hand-created `dex-clients` Secret:
+```sh
+kubectl -n dex create secret generic dex-clients \
+  --from-literal=argocd=<secret> \
+  --from-literal=headlamp=<secret> \
+  --from-literal=grafana=<secret>
+```
+Each value must match the client secret configured in the corresponding app
+(e.g. `argocd` here == the OIDC client secret in `argocd-secret`). A client's
+`redirectURIs` must exactly match what the app sends.
 
 ## Deployment
 Managed by GitOps: the `Application` at `argocd/apps/dex/application.yaml` is

--- a/k8s/dex/dex.yaml
+++ b/k8s/dex/dex.yaml
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  config.yaml: "Y29ubmVjdG9yczoKLSBjb25maWc6CiAgICBjbGllbnRJRDogJEdJVEhVQl9DTElFTlRfSUQKICAgIGNsaWVudFNlY3JldDogJEdJVEhVQl9DTElFTlRfU0VDUkVUCiAgICByZWRpcmVjdFVSSTogaHR0cHM6Ly9kZXgua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9jYWxsYmFjawogIGlkOiBnaXRodWIKICBuYW1lOiBHaXRIdWIKICB0eXBlOiBnaXRodWIKaXNzdWVyOiBodHRwczovL2RleC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyCm9hdXRoMjoKICBza2lwQXBwcm92YWxTY3JlZW46IHRydWUKc3RhdGljQ2xpZW50czoKLSBpZDogZ3JhZmFuYQogIG5hbWU6IEdyYWZhbmEKICByZWRpcmVjdFVSSXM6CiAgLSBodHRwczovL2dyYWZhbmEua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9sb2dpbi9nZW5lcmljX29hdXRoCiAgc2VjcmV0OiBDSEFOR0VfTUVfZ3JhZmFuYQotIGlkOiBhcmdvY2QKICBuYW1lOiBBcmdvQ0QKICByZWRpcmVjdFVSSXM6CiAgLSBodHRwczovL2FyZ29jZC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyL2F1dGgvY2FsbGJhY2sKICBzZWNyZXQ6IENIQU5HRV9NRV9hcmdvY2QKLSBpZDogaGVhZGxhbXAKICBuYW1lOiBIZWFkbGFtcAogIHJlZGlyZWN0VVJJczoKICAtIGh0dHBzOi8vaGVhZGxhbXAua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9vaWRjLWNhbGxiYWNrCiAgc2VjcmV0OiBDSEFOR0VfTUVfaGVhZGxhbXAKc3RvcmFnZToKICBjb25maWc6CiAgICBpbkNsdXN0ZXI6IHRydWUKICB0eXBlOiBrdWJlcm5ldGVzCndlYjoKICBodHRwOiAwLjAuMC4wOjU1NTY="
+  config.yaml: "Y29ubmVjdG9yczoKLSBjb25maWc6CiAgICBjbGllbnRJRDogJEdJVEhVQl9DTElFTlRfSUQKICAgIGNsaWVudFNlY3JldDogJEdJVEhVQl9DTElFTlRfU0VDUkVUCiAgICBvcmdzOgogICAgLSBuYW1lOiBULUNMTy05MDItS3ViZVF1ZXN0CiAgICByZWRpcmVjdFVSSTogaHR0cHM6Ly9kZXgua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9jYWxsYmFjawogIGlkOiBnaXRodWIKICBuYW1lOiBHaXRIdWIKICB0eXBlOiBnaXRodWIKaXNzdWVyOiBodHRwczovL2RleC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyCm9hdXRoMjoKICBza2lwQXBwcm92YWxTY3JlZW46IHRydWUKc3RhdGljQ2xpZW50czoKLSBpZDogZ3JhZmFuYQogIG5hbWU6IEdyYWZhbmEKICByZWRpcmVjdFVSSXM6CiAgLSBodHRwczovL2dyYWZhbmEua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9sb2dpbi9nZW5lcmljX29hdXRoCiAgc2VjcmV0RW52OiBHUkFGQU5BX0NMSUVOVF9TRUNSRVQKLSBpZDogYXJnb2NkCiAgbmFtZTogQXJnb0NECiAgcmVkaXJlY3RVUklzOgogIC0gaHR0cHM6Ly9hcmdvY2Qua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9hdXRoL2NhbGxiYWNrCiAgc2VjcmV0RW52OiBBUkdPQ0RfQ0xJRU5UX1NFQ1JFVAotIGlkOiBoZWFkbGFtcAogIG5hbWU6IEhlYWRsYW1wCiAgcmVkaXJlY3RVUklzOgogIC0gaHR0cHM6Ly9oZWFkbGFtcC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyL29pZGMtY2FsbGJhY2sKICBzZWNyZXRFbnY6IEhFQURMQU1QX0NMSUVOVF9TRUNSRVQKc3RvcmFnZToKICBjb25maWc6CiAgICBpbkNsdXN0ZXI6IHRydWUKICB0eXBlOiBrdWJlcm5ldGVzCndlYjoKICBodHRwOiAwLjAuMC4wOjU1NTY="
 ---
 # Source: dex/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -156,7 +156,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: bbf21ca2305d2cde693014a24807be9f89caedb55d96cbe1128cfee1a373e4e8
+        checksum/config: c8abc20e29257d1746b973923d5cbe0024f173aa8fba560493fc469d7e07d644
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: dex
@@ -189,6 +189,21 @@ spec:
                 secretKeyRef:
                   key: clientSecret
                   name: dex-github
+            - name: ARGOCD_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: argocd
+                  name: dex-clients
+            - name: HEADLAMP_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: headlamp
+                  name: dex-clients
+            - name: GRAFANA_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: grafana
+                  name: dex-clients
           ports:
             - name: http
               containerPort: 5556

--- a/k8s/headlamp/README.md
+++ b/k8s/headlamp/README.md
@@ -58,6 +58,31 @@ The session's effective permissions are the intersection of that token's RBAC
 and the dashboard's reachability — a token from a more privileged ServiceAccount
 grants more in the UI.
 
+## OIDC login (Dex / GitHub)
+Headlamp also offers OIDC login via the cluster-wide external Dex, which
+federates GitHub and only admits the `T-CLO-902-KubeQuest` org. The pod reads
+its OIDC config from env vars wired to a `headlamp-oidc` Secret
+(`OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_ISSUER_URL`, `OIDC_SCOPES`).
+
+That Secret is **created by hand and kept out of Git** — it is the single source
+of truth:
+```sh
+kubectl -n headlamp create secret generic headlamp-oidc \
+  --from-literal=clientID=headlamp \
+  --from-literal=clientSecret=<secret> \
+  --from-literal=issuerURL=https://dex.kubequest.epitech.beer \
+  --from-literal=scopes="openid profile email groups"
+```
+`clientSecret` must equal the `headlamp` value of the `dex-clients` Secret on the
+Dex side.
+
+> Regeneration caveat: this chart (0.43.0) only wires the OIDC env vars via
+> `secretKeyRef` when `config.oidc.secret.create=true`, but that also makes it
+> render a `Secret` from the values (a placeholder `clientSecret`). After
+> `helm template`, **strip that generated `Secret` document** from
+> `k8s/headlamp/headlamp.yaml` so no secret material lands in Git — the
+> Deployment keeps its `secretKeyRef`s to the hand-created `headlamp-oidc`.
+
 ## Deployment
 Managed by GitOps: the `Application` at `argocd/apps/headlamp/application.yaml`
 is picked up by the root app-of-apps and synced automatically. No manual

--- a/k8s/headlamp/headlamp.yaml
+++ b/k8s/headlamp/headlamp.yaml
@@ -12,15 +12,6 @@ metadata:
     app.kubernetes.io/version: "0.43.0"
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: headlamp/templates/secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: oidc
-  namespace: headlamp
-type: Opaque
-data:
----
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -108,12 +99,40 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: headlamp-oidc
+                  key: clientID
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: headlamp-oidc
+                  key: clientSecret
+            - name: OIDC_ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: headlamp-oidc
+                  key: issuerURL
+            - name: OIDC_SCOPES
+              valueFrom:
+                secretKeyRef:
+                  name: headlamp-oidc
+                  key: scopes
           args:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            # Check if clientID is non empty either from env or oidc.config
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            # Check if clientSecret is non empty either from env or oidc.config
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            # Check if issuerURL is non empty either from env or oidc.config
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            # Check if scopes are non empty either from env or oidc.config
+            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466


### PR DESCRIPTION
## What

Connect **ArgoCD** and **Headlamp** to the cluster-wide **Dex** as OIDC clients, federating GitHub. Login is restricted to the `T-CLO-902-KubeQuest` org.

## Dex
- GitHub connector restricted to the `T-CLO-902-KubeQuest` org (`orgs:`).
- Static client secrets moved **out of the rendered manifest** using `secretEnv` (dex >= 2.35.0), fed by a hand-created `dex-clients` Secret.

## ArgoCD
- `configs.cm.url` set to `https://argocd.kubequest.epitech.beer` — was the chart default `argocd.example.com`, which would break OIDC redirects.
- `configs.cm.oidc.config` points at Dex; client secret read from `argocd-secret` (`dex.argocd-client-secret`), kept out of Git.
- SSO users default to `role:readonly`; **admin stays the local account**.

## Headlamp
- `config.oidc` enabled against Dex. This chart only wires OIDC env via `secretKeyRef` when `secret.create=true`, which also renders a Secret — so the generated Secret is **stripped** from the manifest. The real `headlamp-oidc` Secret is hand-created.

## Secrets to create by hand before sync (kept out of Git)
```sh
# Dex side: one shared secret per client
kubectl -n dex create secret generic dex-clients \
  --from-literal=argocd=<S1> --from-literal=headlamp=<S2> --from-literal=grafana=<S3>

# ArgoCD side: must equal dex-clients/argocd
kubectl -n argocd patch secret argocd-secret \
  -p '{"stringData":{"dex.argocd-client-secret":"<S1>"}}'

# Headlamp side: clientSecret must equal dex-clients/headlamp
kubectl -n headlamp create secret generic headlamp-oidc \
  --from-literal=clientID=headlamp --from-literal=clientSecret=<S2> \
  --from-literal=issuerURL=https://dex.kubequest.epitech.beer \
  --from-literal=scopes='openid profile email groups'
```

No secret material is committed — verified the rendered manifests contain no plaintext client secrets.