### PR TITLE
fix(headlamp): drop openid from oidc scopes (dex rejects duplicate)

### DIFF
--- a/helm/headlamp/values.yaml
+++ b/helm/headlamp/values.yaml
@@ -40,8 +40,12 @@ config:
   #     --from-literal=clientID=headlamp \
   #     --from-literal=clientSecret=<secret> \
   #     --from-literal=issuerURL=https://dex.kubequest.epitech.beer \
-  #     --from-literal=scopes="openid profile email groups"
+  #     --from-literal=scopes="profile email groups"
   # clientSecret must match the "headlamp" value of the dex-clients Secret.
+  #
+  # NOTE: do NOT include "openid" in scopes — Headlamp prepends it itself, and a
+  # duplicate "openid openid ..." is rejected by Dex (login fails). List only the
+  # extra scopes here.
   oidc:
     secret:
       create: true
@@ -49,7 +53,7 @@ config:
     clientID: headlamp
     clientSecret: PLACEHOLDER_STRIPPED_FROM_MANIFEST
     issuerURL: https://dex.kubequest.epitech.beer
-    scopes: "openid profile email groups"
+    scopes: "profile email groups"
 
 # The chart creates a ServiceAccount for the pod and binds it to a ClusterRole.
 serviceAccount:

--- a/k8s/headlamp/README.md
+++ b/k8s/headlamp/README.md
@@ -71,10 +71,14 @@ kubectl -n headlamp create secret generic headlamp-oidc \
   --from-literal=clientID=headlamp \
   --from-literal=clientSecret=<secret> \
   --from-literal=issuerURL=https://dex.kubequest.epitech.beer \
-  --from-literal=scopes="openid profile email groups"
+  --from-literal=scopes="profile email groups"
 ```
 `clientSecret` must equal the `headlamp` value of the `dex-clients` Secret on the
 Dex side.
+
+> Do **not** put `openid` in `scopes`: Headlamp prepends it automatically, and a
+> duplicated `openid openid ...` is rejected by Dex, so the login fails. List
+> only the extra scopes (`profile email groups`).
 
 > Regeneration caveat: this chart (0.43.0) only wires the OIDC env vars via
 > `secretKeyRef` when `config.oidc.secret.create=true`, but that also makes it


### PR DESCRIPTION
## Problem
Headlamp OIDC login failed while ArgoCD worked. The auth request Headlamp sent to Dex had a **duplicated scope**:
```
scope=openid+openid+profile+email+groups
```
Headlamp always prepends `openid` itself, so listing `openid` again in `scopes` produces a duplicate that Dex rejects.

## Fix
Set headlamp OIDC `scopes` to `profile email groups` (no `openid`). After the fix the request is `scope=openid+profile+email+groups` (verified live via `/oidc?cluster=main`).

- `helm/headlamp/values.yaml` + README updated, with a note explaining the gotcha.
- Rendered manifest unchanged (scopes live in the hand-created `headlamp-oidc` Secret, which was patched live the same way).

## Verify
```sh
curl -s -D - -o /dev/null 'https://headlamp.kubequest.epitech.beer/oidc?cluster=main' | grep -i location
# -> scope=openid+profile+email+groups (single openid)
```