### PR TITLE
feat(oidc): wire kube-apiserver to dex and grant org read-only RBAC

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -2,3 +2,15 @@
 kubernetes_version: "1.33"
 kubernetes_package_version: "1.33.11"
 kubernetes_pod_subnet: "10.244.0.0/16"
+
+# OIDC for the kube-apiserver: validate bearer tokens issued by the cluster-wide
+# Dex (so Headlamp users authenticated through Dex can reach the API). The
+# client_id MUST equal the audience of the tokens Headlamp obtains (its OIDC
+# client id). Username/groups are prefixed to avoid clashing with built-in or
+# certificate identities.
+apiserver_oidc_issuer_url: "https://dex.kubequest.epitech.beer"
+apiserver_oidc_client_id: "headlamp"
+apiserver_oidc_username_claim: "email"
+apiserver_oidc_username_prefix: "oidc:"
+apiserver_oidc_groups_claim: "groups"
+apiserver_oidc_groups_prefix: "oidc:"

--- a/ansible/roles/control-plane/tasks/apiserver-oidc.yml
+++ b/ansible/roles/control-plane/tasks/apiserver-oidc.yml
@@ -1,0 +1,36 @@
+---
+# Wire the kube-apiserver to Dex as an OIDC token validator.
+#
+# kubeadm init (kubeadm-init.yml) does not take --oidc-* flags on its CLI and is
+# guarded to run only once, so the flags are injected here by patching the static
+# pod manifest. kubelet notices the file change and restarts the apiserver
+# automatically (~30-60s of API downtime). The task is idempotent: each flag is
+# only added if absent, and it reports "changed" only when it actually edits the
+# manifest, so re-running the playbook on a live cluster is safe.
+- name: Ensure kube-apiserver OIDC flags are present
+  ansible.builtin.lineinfile:
+    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+    # Insert each flag right after the `- kube-apiserver` command entry so it
+    # lands inside the container's command list with the correct indentation.
+    insertafter: '^\s*- kube-apiserver$'
+    line: "    - {{ item }}"
+    state: present
+  loop:
+    - "--oidc-issuer-url={{ apiserver_oidc_issuer_url }}"
+    - "--oidc-client-id={{ apiserver_oidc_client_id }}"
+    - "--oidc-username-claim={{ apiserver_oidc_username_claim }}"
+    - "--oidc-username-prefix={{ apiserver_oidc_username_prefix }}"
+    - "--oidc-groups-claim={{ apiserver_oidc_groups_claim }}"
+    - "--oidc-groups-prefix={{ apiserver_oidc_groups_prefix }}"
+  register: apiserver_oidc_patch
+
+- name: Wait for the kube-apiserver to become healthy again after the restart
+  ansible.builtin.uri:
+    url: "https://{{ ansible_default_ipv4.address }}:6443/healthz"
+    validate_certs: false
+    return_content: true
+  register: apiserver_healthz
+  until: apiserver_healthz.status == 200 and apiserver_healthz.content == 'ok'
+  retries: 30
+  delay: 5
+  when: apiserver_oidc_patch is changed

--- a/ansible/roles/control-plane/tasks/main.yml
+++ b/ansible/roles/control-plane/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - import_tasks: kubeadm-init.yml
 - import_tasks: kubeconfig.yml
+- import_tasks: apiserver-oidc.yml

--- a/argocd/apps/oidc-rbac/application.yaml
+++ b/argocd/apps/oidc-rbac/application.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: oidc-rbac
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/T-CLO-902-KubeQuest/KubeQuest.git
+    targetRevision: main
+    path: k8s/oidc-rbac
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/dex/README.md
+++ b/k8s/dex/README.md
@@ -4,8 +4,9 @@
 [Dex](https://dexidp.io/) is the cluster's application-level OIDC provider
 (Issue #10). Cluster services — Headlamp, Grafana, Argo CD, ... — delegate their
 login to Dex, which in turn **federates GitHub** as the upstream identity
-provider. The Kubernetes API server is **not** wired to Dex here; this is SSO for
-the dashboards/apps, not for `kubectl`.
+provider. The Kubernetes API server is also wired to Dex as an OIDC token
+validator (see `k8s/oidc-rbac/` and the `control-plane` Ansible role), so tokens
+minted via Dex are accepted by the API too — bound read-only to the GitHub org.
 
 This is the single, cluster-wide Dex the Argo CD install intentionally leaves
 out of its own bundle (see `argocd/README.md` → "Minimal footprint"). Wire Argo

--- a/k8s/oidc-rbac/README.md
+++ b/k8s/oidc-rbac/README.md
@@ -1,0 +1,25 @@
+# OIDC cluster RBAC
+
+Binds cluster permissions to identities authenticated through Dex.
+
+## Why
+The kube-apiserver is wired to Dex as an OIDC token validator (Ansible role
+`control-plane`, `apiserver-oidc.yml`): `--oidc-issuer-url` points at Dex,
+`--oidc-client-id=headlamp`, with `--oidc-username-prefix=oidc:` and
+`--oidc-groups-prefix=oidc:`. Without a binding, an SSO user authenticates but
+has **no** permissions (every API call 403s).
+
+Dex only admits the `T-CLO-902-KubeQuest` GitHub org, so each SSO user carries
+the group `oidc:T-CLO-902-KubeQuest`. `cluster-view.yaml` binds that group to the
+built-in **`view`** ClusterRole — read-only, consistent with Headlamp's stance.
+
+## Scope
+- Read-only only. Privileged access stays with kubeconfig / certificate
+  identities, not granted through SSO.
+- To promote a specific GitHub team, add a binding for its group
+  (`oidc:T-CLO-902-KubeQuest:<team>`) to a stronger role.
+
+## Deployment
+GitOps: `argocd/apps/oidc-rbac/application.yaml` is synced by the root app. The
+`ClusterRoleBinding` is cluster-scoped; the Application's destination namespace
+(`kube-system`) is only a placeholder Argo CD requires.

--- a/k8s/oidc-rbac/cluster-view.yaml
+++ b/k8s/oidc-rbac/cluster-view.yaml
@@ -1,0 +1,23 @@
+# Grant read-only cluster access to users authenticated through Dex.
+#
+# The kube-apiserver is wired to Dex (see ansible role control-plane,
+# apiserver-oidc.yml) with --oidc-groups-prefix=oidc: and --oidc-groups-claim=
+# groups. Dex only admits the T-CLO-902-KubeQuest GitHub org, so every SSO user
+# carries the group "oidc:T-CLO-902-KubeQuest". Bind that group to the built-in
+# "view" ClusterRole — read-only, matching Headlamp's read-only stance.
+#
+# Privileged access is NOT granted here: it stays with kubeconfig/certificate
+# identities. Promote a specific GitHub team later with its own binding to a
+# stronger role (e.g. "oidc:T-CLO-902-KubeQuest:maintainers" -> edit/admin).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oidc-org-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: "oidc:T-CLO-902-KubeQuest"


### PR DESCRIPTION
## Problem (proven in logs)
Headlamp login via Dex worked, but every API call returned **401**:
```
selfsubjectrulesreviews -> 401 Unauthorized
```
kube-apiserver logs showed the root cause:
```
authentication.go:75 "Unable to authenticate the request" err="invalid bearer token"
```
Headlamp forwards the Dex token to the API server, but the API server was **never configured as an OIDC validator** (no `--oidc-*` flags), so it rejects any Dex token. By design so far Dex was app-level SSO only; this PR extends it to the API.

## Changes
- **ansible** — `control-plane/apiserver-oidc.yml`: idempotent task injecting `--oidc-*` flags into the static apiserver manifest, then waiting on `/healthz`. `kubeadm init` runs once and takes no `--oidc-*` CLI flags, so they are patched post-init. Vars in `group_vars/all.yml`:
  - issuer = `https://dex.kubequest.epitech.beer`, client-id = `headlamp` (the token `aud`), username claim `email`, groups claim `groups`, both `oidc:`-prefixed.
- **k8s/oidc-rbac** — `ClusterRoleBinding` of group `oidc:T-CLO-902-KubeQuest` to the built-in `view` ClusterRole (read-only), synced by a new Argo CD app.
- **docs** — fix the dex README note that said the API server is not wired to Dex.

## Risk / rollout
Editing the static apiserver manifest restarts kube-apiserver (~30-60s API downtime). A typo can crashloop it. The Ansible task only adds absent flags and waits for healthz. **Apply by running the control-plane role** against the CP node (I cannot reach `10.2.41.155` from here).

## Verify after apply
```sh
kubectl -n kube-system get pod -l component=kube-apiserver \
  -o jsonpath='{.items[0].spec.containers[0].command}' | tr ',' '\n' | grep oidc
kubectl get --raw=/healthz   # ok
# then retry the Headlamp call that 401'd
```
Privileged access stays with kubeconfig/certificate identities — SSO is read-only.