### PR TITLE
feat(oauth2-proxy): shared OIDC auth layer for exposed tools

### DIFF
--- a/argocd/apps/oauth2-proxy/application.yaml
+++ b/argocd/apps/oauth2-proxy/application.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: oauth2-proxy
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/T-CLO-902-KubeQuest/KubeQuest.git
+    targetRevision: main
+    path: k8s/oauth2-proxy
+    directory:
+      include: "{oauth2-proxy.yaml,ingress.yaml}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: oauth2-proxy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/helm/dex/values.yaml
+++ b/helm/dex/values.yaml
@@ -82,6 +82,14 @@ config:
       secretEnv: HEADLAMP_CLIENT_SECRET
       redirectURIs:
         - https://headlamp.kubequest.epitech.beer/oidc-callback
+    # Shared auth layer (Issue #11): the front door for tools that have no auth of
+    # their own. Tools delegate to it via nginx forward-auth; it owns this single
+    # callback regardless of how many tools sit behind it.
+    - id: oauth2-proxy
+      name: oauth2-proxy
+      secretEnv: OAUTH2_PROXY_CLIENT_SECRET
+      redirectURIs:
+        - https://auth.kubequest.epitech.beer/oauth2/callback
 
 # Secrets injected into the Dex pod, all sourced from hand-created Kubernetes
 # Secrets (never committed):
@@ -94,7 +102,8 @@ config:
 #   kubectl -n dex create secret generic dex-clients \
 #     --from-literal=argocd=<secret> \
 #     --from-literal=headlamp=<secret> \
-#     --from-literal=grafana=<secret>
+#     --from-literal=grafana=<secret> \
+#     --from-literal=oauth2-proxy=<secret>
 envVars:
   - name: GITHUB_CLIENT_ID
     valueFrom:
@@ -121,6 +130,11 @@ envVars:
       secretKeyRef:
         name: dex-clients
         key: grafana
+  - name: OAUTH2_PROXY_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: dex-clients
+        key: oauth2-proxy
 
 # Internal only; traffic reaches Dex through the standalone Ingress
 # (k8s/dex/ingress.yaml), so ClusterIP — never LoadBalancer/NodePort.

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -1,0 +1,101 @@
+# oauth2-proxy values used to render k8s/oauth2-proxy/oauth2-proxy.yaml.
+# Chart repo: https://oauth2-proxy.github.io/manifests  (chart: oauth2-proxy/oauth2-proxy)
+# Regenerate the manifest with:
+#   helm repo add oauth2-proxy https://oauth2-proxy.github.io/manifests
+#   helm repo update oauth2-proxy
+#   helm template oauth2-proxy oauth2-proxy/oauth2-proxy \
+#     --version <CHART_VERSION> \
+#     --namespace oauth2-proxy \
+#     --values helm/oauth2-proxy/values.yaml \
+#     > k8s/oauth2-proxy/oauth2-proxy.yaml
+#
+# Pinned chart version: 10.7.0 (app version 7.15.3).
+#
+# oauth2-proxy is the cluster's shared authentication layer (Issue #11). It sits
+# in front of tools that have no auth of their own (Prometheus, Alertmanager) or
+# whose auth we'd rather not expose (Grafana). Those tools' Ingresses delegate
+# auth to it via nginx's auth_request (forward-auth): unauthenticated requests
+# are bounced to Dex (which federates GitHub, org-restricted), and only return to
+# the tool once a session cookie is present. One proxy, many tools — each opted in
+# by annotations on its own Ingress (see k8s/oauth2-proxy/README.md).
+#
+# Nothing sits behind it yet: this ticket ships the auth layer ready to use; the
+# first protected tool (Prometheus/Grafana) wires itself in later.
+#
+# Only values that diverge from the chart defaults are set below.
+
+# Single replica: no HA requirement on this cluster.
+replicaCount: 1
+
+# Talk OIDC to the cluster-wide Dex. The proxy is a Dex staticClient (id
+# "oauth2-proxy", declared in helm/dex/values.yaml).
+config:
+  # Client id/secret and the cookie secret come from a hand-created Secret, never
+  # from Git (see existingSecret below). Leave these empty so the chart renders no
+  # secret material into the manifest.
+  clientID: ""
+  clientSecret: ""
+  cookieSecret: ""
+  # Use the hand-created Secret as the single source of truth for credentials:
+  #   # 32-byte cookie secret (AES — must be 16/24/32 bytes):
+  #   #   openssl rand -base64 32 | tr -d '\n'
+  #   kubectl -n oauth2-proxy create secret generic oauth2-proxy \
+  #     --from-literal=client-id=oauth2-proxy \
+  #     --from-literal=client-secret=<secret> \
+  #     --from-literal=cookie-secret=<32-byte-base64>
+  # client-secret must match the "oauth2-proxy" value of the dex-clients Secret.
+  existingSecret: oauth2-proxy
+
+# Extra flags not exposed as first-class chart values.
+extraArgs:
+  provider: oidc
+  oidc-issuer-url: https://dex.kubequest.epitech.beer
+  # The callback Dex redirects back to — must exactly match the staticClient's
+  # redirectURI in helm/dex/values.yaml.
+  redirect-url: https://auth.kubequest.epitech.beer/oauth2/callback
+  # Dex already restricts login to the T-CLO-902-KubeQuest GitHub org, so any user
+  # it authenticates is allowed through — no further email-domain filtering.
+  email-domain: "*"
+  # Forward-auth across sub-domains: scope the session cookie to the parent domain
+  # so a single login covers every *.kubequest.epitech.beer tool (true SSO), and
+  # allow redirects back to any of them after auth.
+  cookie-domain: ".kubequest.epitech.beer"
+  whitelist-domain: ".kubequest.epitech.beer"
+  # Hand the upstream tool the authenticated identity.
+  set-xauthrequest: "true"
+  pass-access-token: "true"
+  # Reverse-proxy mode: trust X-Forwarded-* from ingress-nginx (which terminates
+  # TLS and sets these headers). The chart already sets --http-address.
+  reverse-proxy: "true"
+
+# Session cookie hardening: the chart's defaults are already Secure=true and
+# HttpOnly=true, so the cookie is never sent over plain HTTP nor readable from JS.
+# Combined with cookie-domain above, one hardened cookie covers all sub-domains.
+
+# Internal only; traffic reaches the proxy through the standalone Ingress
+# (k8s/oauth2-proxy/ingress.yaml), so ClusterIP — never LoadBalancer/NodePort.
+service:
+  type: ClusterIP
+  portNumber: 4180
+
+# Ingress is declared as a standalone manifest (like Dex's and Headlamp's, in
+# k8s/oauth2-proxy/ingress.yaml) so TLS via cert-manager lives next to it and
+# stays a reviewable diff. Keep the chart's own Ingress off to avoid two sources.
+ingress:
+  enabled: false
+
+# Constrained cluster: cap the proxy rather than let it burst.
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 64Mi
+
+# This chart bundles a redis subchart for session storage; we use cookie-based
+# sessions (the default), so keep it off.
+sessionStorage:
+  type: cookie
+redis:
+  enabled: false

--- a/k8s/dex/README.md
+++ b/k8s/dex/README.md
@@ -59,15 +59,19 @@ groups to clients that request the `groups` scope.
 
 ## Clients
 Each service that logs in through Dex is declared as a `staticClient` in
-`helm/dex/values.yaml` (Grafana, Argo CD, Headlamp). Client secrets are **not**
-in Git: each entry uses `secretEnv` (dex >= 2.35.0) to read its secret from an
-env var, fed by a hand-created `dex-clients` Secret:
+`helm/dex/values.yaml` (Grafana, Argo CD, Headlamp, oauth2-proxy). Client secrets
+are **not** in Git: each entry uses `secretEnv` (dex >= 2.35.0) to read its secret
+from an env var, fed by a hand-created `dex-clients` Secret:
 ```sh
 kubectl -n dex create secret generic dex-clients \
   --from-literal=argocd=<secret> \
   --from-literal=headlamp=<secret> \
-  --from-literal=grafana=<secret>
+  --from-literal=grafana=<secret> \
+  --from-literal=oauth2-proxy=<secret>
 ```
+The `oauth2-proxy` client is the shared auth layer (Issue #11) that fronts tools
+without their own login (Prometheus, Grafana, ...); see
+`k8s/oauth2-proxy/README.md`.
 Each value must match the client secret configured in the corresponding app
 (e.g. `argocd` here == the OIDC client secret in `argocd-secret`). A client's
 `redirectURIs` must exactly match what the app sends.

--- a/k8s/dex/dex.yaml
+++ b/k8s/dex/dex.yaml
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  config.yaml: "Y29ubmVjdG9yczoKLSBjb25maWc6CiAgICBjbGllbnRJRDogJEdJVEhVQl9DTElFTlRfSUQKICAgIGNsaWVudFNlY3JldDogJEdJVEhVQl9DTElFTlRfU0VDUkVUCiAgICBvcmdzOgogICAgLSBuYW1lOiBULUNMTy05MDItS3ViZVF1ZXN0CiAgICByZWRpcmVjdFVSSTogaHR0cHM6Ly9kZXgua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9jYWxsYmFjawogIGlkOiBnaXRodWIKICBuYW1lOiBHaXRIdWIKICB0eXBlOiBnaXRodWIKaXNzdWVyOiBodHRwczovL2RleC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyCm9hdXRoMjoKICBza2lwQXBwcm92YWxTY3JlZW46IHRydWUKc3RhdGljQ2xpZW50czoKLSBpZDogZ3JhZmFuYQogIG5hbWU6IEdyYWZhbmEKICByZWRpcmVjdFVSSXM6CiAgLSBodHRwczovL2dyYWZhbmEua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9sb2dpbi9nZW5lcmljX29hdXRoCiAgc2VjcmV0RW52OiBHUkFGQU5BX0NMSUVOVF9TRUNSRVQKLSBpZDogYXJnb2NkCiAgbmFtZTogQXJnb0NECiAgcmVkaXJlY3RVUklzOgogIC0gaHR0cHM6Ly9hcmdvY2Qua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9hdXRoL2NhbGxiYWNrCiAgc2VjcmV0RW52OiBBUkdPQ0RfQ0xJRU5UX1NFQ1JFVAotIGlkOiBoZWFkbGFtcAogIG5hbWU6IEhlYWRsYW1wCiAgcmVkaXJlY3RVUklzOgogIC0gaHR0cHM6Ly9oZWFkbGFtcC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyL29pZGMtY2FsbGJhY2sKICBzZWNyZXRFbnY6IEhFQURMQU1QX0NMSUVOVF9TRUNSRVQKc3RvcmFnZToKICBjb25maWc6CiAgICBpbkNsdXN0ZXI6IHRydWUKICB0eXBlOiBrdWJlcm5ldGVzCndlYjoKICBodHRwOiAwLjAuMC4wOjU1NTY="
+  config.yaml: "Y29ubmVjdG9yczoKLSBjb25maWc6CiAgICBjbGllbnRJRDogJEdJVEhVQl9DTElFTlRfSUQKICAgIGNsaWVudFNlY3JldDogJEdJVEhVQl9DTElFTlRfU0VDUkVUCiAgICBvcmdzOgogICAgLSBuYW1lOiBULUNMTy05MDItS3ViZVF1ZXN0CiAgICByZWRpcmVjdFVSSTogaHR0cHM6Ly9kZXgua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9jYWxsYmFjawogIGlkOiBnaXRodWIKICBuYW1lOiBHaXRIdWIKICB0eXBlOiBnaXRodWIKaXNzdWVyOiBodHRwczovL2RleC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyCm9hdXRoMjoKICBza2lwQXBwcm92YWxTY3JlZW46IHRydWUKc3RhdGljQ2xpZW50czoKLSBpZDogZ3JhZmFuYQogIG5hbWU6IEdyYWZhbmEKICByZWRpcmVjdFVSSXM6CiAgLSBodHRwczovL2dyYWZhbmEua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9sb2dpbi9nZW5lcmljX29hdXRoCiAgc2VjcmV0RW52OiBHUkFGQU5BX0NMSUVOVF9TRUNSRVQKLSBpZDogYXJnb2NkCiAgbmFtZTogQXJnb0NECiAgcmVkaXJlY3RVUklzOgogIC0gaHR0cHM6Ly9hcmdvY2Qua3ViZXF1ZXN0LmVwaXRlY2guYmVlci9hdXRoL2NhbGxiYWNrCiAgc2VjcmV0RW52OiBBUkdPQ0RfQ0xJRU5UX1NFQ1JFVAotIGlkOiBoZWFkbGFtcAogIG5hbWU6IEhlYWRsYW1wCiAgcmVkaXJlY3RVUklzOgogIC0gaHR0cHM6Ly9oZWFkbGFtcC5rdWJlcXVlc3QuZXBpdGVjaC5iZWVyL29pZGMtY2FsbGJhY2sKICBzZWNyZXRFbnY6IEhFQURMQU1QX0NMSUVOVF9TRUNSRVQKLSBpZDogb2F1dGgyLXByb3h5CiAgbmFtZTogb2F1dGgyLXByb3h5CiAgcmVkaXJlY3RVUklzOgogIC0gaHR0cHM6Ly9hdXRoLmt1YmVxdWVzdC5lcGl0ZWNoLmJlZXIvb2F1dGgyL2NhbGxiYWNrCiAgc2VjcmV0RW52OiBPQVVUSDJfUFJPWFlfQ0xJRU5UX1NFQ1JFVApzdG9yYWdlOgogIGNvbmZpZzoKICAgIGluQ2x1c3RlcjogdHJ1ZQogIHR5cGU6IGt1YmVybmV0ZXMKd2ViOgogIGh0dHA6IDAuMC4wLjA6NTU1Ng=="
 ---
 # Source: dex/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -156,7 +156,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: c8abc20e29257d1746b973923d5cbe0024f173aa8fba560493fc469d7e07d644
+        checksum/config: 4346286e36d4cb0a4e66fd13a2e03ddde9158b1f70522d40e5d69c510b29e212
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: dex
@@ -203,6 +203,11 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: grafana
+                  name: dex-clients
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: oauth2-proxy
                   name: dex-clients
           ports:
             - name: http

--- a/k8s/oauth2-proxy/README.md
+++ b/k8s/oauth2-proxy/README.md
@@ -1,0 +1,110 @@
+# oauth2-proxy (shared authentication layer)
+
+## Overview
+[oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) is the cluster's
+shared authentication layer (Issue #11). It sits in front of tools that have no
+authentication of their own — Prometheus, Alertmanager — or whose auth we would
+rather not expose directly (Grafana). Instead of teaching every tool OIDC, those
+tools delegate their authentication to this one proxy, which speaks OIDC to the
+cluster-wide **Dex** (which federates GitHub and only admits the
+`T-CLO-902-KubeQuest` org).
+
+Headlamp and Argo CD are **not** behind this proxy: they speak OIDC to Dex
+natively (see `k8s/headlamp/README.md` and `argocd/README.md`). oauth2-proxy is
+for the tools that can't.
+
+> Nothing sits behind the proxy yet. This ticket ships the auth layer **ready to
+> use**; the first protected tool (Prometheus/Grafana) wires itself in later via
+> the annotations documented below.
+
+## How it protects a tool (nginx forward-auth)
+ingress-nginx supports `auth_request`: before routing a request to a tool, it
+fires a sub-request to oauth2-proxy. If there's no valid session, the proxy
+returns 401 and nginx bounces the user to Dex; once a session cookie is present
+the proxy returns 202 and nginx lets the request through.
+
+```
+User → nginx ─auth_request→ oauth2-proxy ─OIDC→ Dex → GitHub (org-restricted)
+            └─ 202 + cookie ─────────────────→ tool (prometheus, grafana, ...)
+```
+
+The proxy serves the OIDC dance on its own host,
+**https://auth.kubequest.epitech.beer** (`/oauth2/start`, `/oauth2/callback`,
+`/oauth2/auth`).
+
+## Protecting a future tool
+Add these annotations to that tool's **own** Ingress — no change to oauth2-proxy
+itself:
+
+```yaml
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: "https://auth.kubequest.epitech.beer/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.kubequest.epitech.beer/oauth2/start?rd=$escaped_request_uri"
+```
+
+That's the whole opt-in. Because the session cookie is scoped to the parent
+domain (`--cookie-domain=.kubequest.epitech.beer`), one login covers every
+`*.kubequest.epitech.beer` tool — true SSO across sub-domains. Each protected
+host needs the usual CoreDNS `hosts` entry for its cert-manager HTTP-01
+self-check (see `k8s/cert-manager/README.md`).
+
+## Authorization
+`--email-domain=*` lets through anyone Dex authenticates. That is **not** an open
+door: Dex's GitHub connector already restricts login to members of the
+`T-CLO-902-KubeQuest` org, so org membership is the access boundary. Tighten to a
+specific team later with `--allowed-groups` if needed — but note Dex's GitHub
+`groups` claim has been unreliable on this cluster (see `k8s/oidc-rbac/README.md`).
+
+## Design: vendored manifest
+Like Dex, Argo CD, ingress-nginx and Headlamp, oauth2-proxy is installed from a
+manifest checked into the repo (`k8s/oauth2-proxy/oauth2-proxy.yaml`), rendered
+with `helm template` — never `helm install` (no Helm release state on the
+cluster). Every change is a reviewable diff alongside its source values
+(`helm/oauth2-proxy/values.yaml`).
+
+### Regenerating the manifest
+```sh
+helm repo add oauth2-proxy https://oauth2-proxy.github.io/manifests
+helm repo update oauth2-proxy
+helm template oauth2-proxy oauth2-proxy/oauth2-proxy \
+  --version <CHART_VERSION> \
+  --namespace oauth2-proxy \
+  --values helm/oauth2-proxy/values.yaml \
+  > k8s/oauth2-proxy/oauth2-proxy.yaml
+```
+Pinned chart version: **10.7.0** (app version 7.15.3). Bump it here and in the
+command above, then commit the regenerated manifest with the values change.
+
+## Exposure & TLS
+The `Service` stays `ClusterIP` (port 4180, plain HTTP); traffic reaches the
+proxy through a standalone `Ingress` (`k8s/oauth2-proxy/ingress.yaml`) on the
+`nginx` IngressClass, with TLS issued by cert-manager on the `letsencrypt-prod`
+issuer (validated on `letsencrypt-staging` first). The HTTP-01 self-check needs a
+CoreDNS `hosts` entry for `auth.kubequest.epitech.beer` — see
+`k8s/cert-manager/README.md`.
+
+## Secrets (created by hand, kept out of Git)
+The proxy reads its credentials from a hand-created `oauth2-proxy` Secret in the
+`oauth2-proxy` namespace — the single source of truth:
+
+```sh
+# Cookie secret must be 16, 24 or 32 bytes (AES); generate 32 bytes:
+#   openssl rand -base64 32 | tr -d '\n'
+kubectl -n oauth2-proxy create secret generic oauth2-proxy \
+  --from-literal=client-id=oauth2-proxy \
+  --from-literal=client-secret=<secret> \
+  --from-literal=cookie-secret=<32-byte-base64>
+```
+
+`client-secret` must equal the `oauth2-proxy` value of the `dex-clients` Secret
+on the Dex side (see `k8s/dex/README.md`). The session cookie is **Secure** and
+**HttpOnly** (chart defaults), so it never travels over plain HTTP nor is
+readable from JavaScript.
+
+## Deployment
+Managed by GitOps: the `Application` at `argocd/apps/oauth2-proxy/application.yaml`
+is picked up by the root app-of-apps and synced automatically. No manual
+`kubectl apply` — but the `oauth2-proxy` Secret above must exist in the namespace
+before the pod can start, and the `oauth2-proxy` key must be present in the
+`dex-clients` Secret before Dex will accept the client.

--- a/k8s/oauth2-proxy/ingress.yaml
+++ b/k8s/oauth2-proxy/ingress.yaml
@@ -1,0 +1,34 @@
+# Ingress exposing oauth2-proxy at auth.kubequest.epitech.beer.
+#
+# This is the proxy's own host: it serves the OIDC dance (/oauth2/start,
+# /oauth2/callback, /oauth2/auth) that protected tools delegate to via
+# nginx auth_request. oauth2-proxy serves plain HTTP on its Service (port 4180),
+# so no backend-protocol annotation is needed — HTTP is ingress-nginx's default.
+#
+# TLS is issued by the letsencrypt-prod ClusterIssuer (HTTP-01). The chain was
+# first validated on letsencrypt-staging; see k8s/cert-manager/README.md for the
+# CoreDNS hosts entry that lets the HTTP-01 self-check resolve internally.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - auth.kubequest.epitech.beer
+      secretName: oauth2-proxy-tls
+  rules:
+    - host: auth.kubequest.epitech.beer
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: oauth2-proxy
+                port:
+                  number: 4180

--- a/k8s/oauth2-proxy/oauth2-proxy.yaml
+++ b/k8s/oauth2-proxy/oauth2-proxy.yaml
@@ -1,0 +1,197 @@
+---
+# Source: oauth2-proxy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/version: "7.15.3"
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+automountServiceAccountToken: true
+---
+# Source: oauth2-proxy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/version: "7.15.3"
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+data:
+  oauth2_proxy.cfg: |
+
+    email_domains = ["*"]
+    upstreams = ["file:///dev/null"]
+---
+# Source: oauth2-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/version: "7.15.3"
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4180
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+      name: http
+    - port: 44180
+      protocol: TCP
+      appProtocol: http
+      targetPort: metrics
+      name: metrics
+  selector:    
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+---
+# Source: oauth2-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-10.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/version: "7.15.3"
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy
+  template:
+    metadata:
+      annotations:
+        checksum/config: 052b3706583beb7047e0b3b36032555fdf49a204a18c93f7097d078005c2b9bf
+        checksum/secret: bc51d28490f7963a08cc40ecbe74f45bb9587d9b8ac9591b0797b4537d2ade01
+        checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+      labels:
+        app: oauth2-proxy        
+        helm.sh/chart: oauth2-proxy-10.7.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: authentication-proxy
+        app.kubernetes.io/part-of: oauth2-proxy
+        app.kubernetes.io/name: oauth2-proxy
+        app.kubernetes.io/instance: oauth2-proxy
+        app.kubernetes.io/version: "7.15.3"
+    spec:
+      serviceAccountName: oauth2-proxy
+      enableServiceLinks: true
+      automountServiceAccountToken: true
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.15.3"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --http-address=0.0.0.0:4180
+          - --https-address=0.0.0.0:4443
+          - --metrics-address=0.0.0.0:44180
+          - --cookie-domain=.kubequest.epitech.beer
+          - --email-domain=*
+          - --oidc-issuer-url=https://dex.kubequest.epitech.beer
+          - --pass-access-token=true
+          - --provider=oidc
+          - --redirect-url=https://auth.kubequest.epitech.beer/oauth2/callback
+          - --reverse-proxy=true
+          - --set-xauthrequest=true
+          - --whitelist-domain=.kubequest.epitech.beer
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy
+              key: client-id
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy
+              key: client-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy
+              key: cookie-secret
+        ports:
+          - containerPort: 4180
+            name: http
+            protocol: TCP
+          - containerPort: 44180
+            protocol: TCP
+            name: metrics
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 5
+          successThreshold: 1
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
+          name: configmain
+          subPath: oauth2_proxy.cfg
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 2000
+          runAsNonRoot: true
+          runAsUser: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: oauth2-proxy
+        name: configmain


### PR DESCRIPTION
Closes #11.

## Contexte
Les outils sensibles exposés via Ingress (Prometheus, Grafana, Alertmanager…) ne doivent pas l'être sans authentification. Ce PR ajoute une **couche d'authentification commune** devant ces outils, déléguant l'auth au provider OIDC central (Dex → GitHub, restreint à l'org `T-CLO-902-KubeQuest`).

Headlamp et Argo CD parlent OIDC nativement à Dex et **ne sont pas** concernés. oauth2-proxy est destiné aux outils qui ne savent pas faire d'OIDC.

## Architecture
\`\`\`
User → nginx ─auth_request→ oauth2-proxy ─OIDC→ Dex → GitHub (org-restricted)
            └─ 202 + cookie ─────────────────→ tool (prometheus, grafana, ...)
\`\`\`
- **Forward-auth nginx** : un seul oauth2-proxy, chaque outil s'y branche par annotations `auth-url`/`auth-signin` sur son propre Ingress.
- **SSO cross-subdomain** : cookie scoppé à `.kubequest.epitech.beer` → un seul login pour tous les `*.kubequest.epitech.beer`.
- **Autorisation** : `email-domain=*`, le filtrage org GitHub étant déjà assuré par Dex.
- **Cookie** Secure + HttpOnly (défauts du chart).

## Portée
Livre **uniquement la couche d'auth, prête à l'emploi** — aucun outil branché derrière (rien à protéger encore). Le branchement de Prometheus/Grafana se fera plus tard via les annotations documentées dans \`k8s/oauth2-proxy/README.md\`.

## Changements
- \`helm/oauth2-proxy/values.yaml\` + \`k8s/oauth2-proxy/oauth2-proxy.yaml\` : chart 10.7.0 rendu via \`helm template\` (manifest vendored, aucun secret inline).
- \`k8s/oauth2-proxy/ingress.yaml\` : host \`auth.kubequest.epitech.beer\` + TLS cert-manager.
- \`argocd/apps/oauth2-proxy/application.yaml\` : Application GitOps (app-of-apps).
- Nouveau staticClient \`oauth2-proxy\` dans Dex (\`helm/dex/values.yaml\`, \`k8s/dex/dex.yaml\`).
- READMEs (\`k8s/oauth2-proxy/\`, \`k8s/dex/\`).

## Prérequis de déploiement (hors Git, documentés)
- Secret \`oauth2-proxy\` (client-id/secret + cookie-secret) dans le namespace \`oauth2-proxy\`.
- Clé \`oauth2-proxy\` dans le Secret \`dex-clients\`.
- Entrée CoreDNS pour \`auth.kubequest.epitech.beer\` (HTTP-01 self-check).

## Critères d'acceptation
- ✅ Accès sans session → redirection vers Dex (forward-auth `auth-signin`).
- ✅ Après authentification → accès au tool (cookie de session présent → 202).

> Validation end-to-end à confirmer une fois un premier outil (Prometheus) branché ; la mécanique forward-auth est celle standard de ingress-nginx.