### PR TITLE
feat(oauth2-proxy): enable PKCE (S256) on the OIDC flow

### DIFF
--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -50,6 +50,11 @@ config:
 extraArgs:
   provider: oidc
   oidc-issuer-url: https://dex.kubequest.epitech.beer
+  # PKCE (RFC 7636) binds the auth code to a per-session secret that never leaves
+  # the proxy, so a stolen code can't be replayed even if the client secret leaks.
+  # Dex advertises S256 support; defence-in-depth on top of the confidential
+  # client secret.
+  code-challenge-method: S256
   # The callback Dex redirects back to — must exactly match the staticClient's
   # redirectURI in helm/dex/values.yaml.
   redirect-url: https://auth.kubequest.epitech.beer/oauth2/callback

--- a/k8s/oauth2-proxy/oauth2-proxy.yaml
+++ b/k8s/oauth2-proxy/oauth2-proxy.yaml
@@ -119,6 +119,7 @@ spec:
           - --http-address=0.0.0.0:4180
           - --https-address=0.0.0.0:4443
           - --metrics-address=0.0.0.0:44180
+          - --code-challenge-method=S256
           - --cookie-domain=.kubequest.epitech.beer
           - --email-domain=*
           - --oidc-issuer-url=https://dex.kubequest.epitech.beer


### PR DESCRIPTION
Follow-up to #50 (Issue #11).

Enable **PKCE** (Proof Key for Code Exchange, RFC 7636) on oauth2-proxy's OIDC flow via `--code-challenge-method=S256`.

## Pourquoi
Au démarrage, oauth2-proxy émet ce warning :
\`\`\`
Warning: Your provider supports PKCE methods ["S256" "plain"],
but you have not enabled one with --code-challenge-method
\`\`\`
PKCE lie le code d'autorisation à un secret éphémère par session (le `code_verifier`) qui ne transite jamais par le navigateur. Un code intercepté ne peut donc pas être rejoué, **même si le client secret venait à fuiter** — défense en profondeur au-dessus du secret du client confidentiel.

Dex annonce le support de `S256` (SHA-256), le seul mode recommandé (`plain` n'apporte rien).

## Changements
- `helm/oauth2-proxy/values.yaml` : ajout de `code-challenge-method: S256`.
- `k8s/oauth2-proxy/oauth2-proxy.yaml` : manifest re-rendu (chart 10.7.0).

Aucun secret ni nouvelle dépendance. Validé par `kubectl apply --dry-run=client`.