### PR TITLE
ci(sample-app): build, Trivy scan and publish image to GHCR

### DIFF
--- a/.github/workflows/sample-app-build.yml
+++ b/.github/workflows/sample-app-build.yml
@@ -1,0 +1,95 @@
+name: Sample App - Build, Scan & Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "sample-app/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/sample-app
+
+jobs:
+  build-scan-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to push the semver tag
+      packages: write # needed to push the image to GHCR
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history is required to compute the semver bump
+
+      - name: Compute next semver tag from conventional commits
+        id: semver
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          release_branches: main
+          dry_run: true # we tag manually below, after a successful push
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.semver.outputs.new_version }}
+            type=raw,value=latest
+            type=sha,format=short
+
+      - name: Build image (load locally for scanning)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./sample-app
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.semver.outputs.new_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.semver.outputs.new_version }}
+          format: table
+          exit-code: "1" # fail the pipeline on findings
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          vuln-type: os,library
+
+      - name: Push image to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: ./sample-app
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create and push semver git tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          release_branches: main
+          custom_tag: ${{ steps.semver.outputs.new_version }}
+          tag_prefix: v


### PR DESCRIPTION
## Résumé
Ajoute une pipeline CI/CD pour la sample-app qui :
- **Build** l'image Docker depuis \`sample-app/\`
- **Scan Trivy** sur l'image (échoue sur \`CRITICAL,HIGH\`, bloque la publication)
- **Publie** sur GHCR avec un tag **semver** dérivé des conventional commits
- Crée le tag git semver après publication réussie

## Déclenchement
Push sur \`main\` modifiant \`sample-app/**\` (+ \`workflow_dispatch\`).

## Notes
- Image : \`ghcr.io/<repo>/sample-app\`, tags \`vX.Y.Z\`, \`latest\`, sha court
- Utilise \`secrets.GITHUB_TOKEN\` (aucun secret supplémentaire à configurer)