### PR TITLE
feat(ci): release helm chart to GHCR with image-aligned semver

### DIFF
--- a/.github/workflows/sample-app-build.yml
+++ b/.github/workflows/sample-app-build.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "sample-app/**"
+      - "helm/sample-app/**"
   workflow_dispatch:
 
 permissions:
@@ -14,6 +15,7 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/sample-app
+  CHART_PATH: ./helm/sample-app
 
 jobs:
   build-scan-publish:
@@ -93,3 +95,33 @@ jobs:
           release_branches: main
           custom_tag: ${{ steps.semver.outputs.new_version }}
           tag_prefix: v
+
+      # --- Helm chart release (same semver as the image just published) ---
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Package and push Helm chart to GHCR
+        env:
+          VERSION: ${{ steps.semver.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          # GHCR requires a lowercase repository path.
+          OWNER_LC="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          REPO_LC="$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          CHART_REF="oci://ghcr.io/${REPO_LC}/charts"
+
+          # Reuse the GITHUB_TOKEN session for the OCI registry.
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io --username '${{ github.actor }}' --password-stdin
+
+          # Chart version and app version both track the image semver, so an
+          # installed chart always references an image tag that exists.
+          helm package "${{ env.CHART_PATH }}" \
+            --version "${VERSION}" \
+            --app-version "${VERSION}" \
+            --destination ./dist
+
+          helm push "./dist/sample-app-${VERSION}.tgz" "${CHART_REF}"
+
+          echo "Published chart ${CHART_REF}/sample-app:${VERSION} (appVersion ${VERSION})"


### PR DESCRIPTION
## Summary
Étend la pipeline existante `sample-app-build.yml` pour publier le **chart Helm** sur GHCR (artefact OCI) en fin de job, après le build/scan/push de l'image.

- Réutilise le tag semver déjà calculé (`steps.semver.outputs.new_version`) pour `--version` (chart) **et** `--app-version` (image) → chart et image partagent toujours la même version.
- Chart poussé sur `oci://ghcr.io/<owner>/kubequest/charts/sample-app` (chemin lowercased pour GHCR).
- `paths` élargi à `helm/sample-app/**` pour redéclencher sur modif du chart.

Comme le chart pinne `image.tag` sur `.Chart.AppVersion`, un chart installé référence toujours un tag d'image qui existe.

## Note
Dépend du merge de #41 (le chart `helm/sample-app` n'est pas encore sur `main`). La step chart restera no-op utile tant que le chart n'y est pas.

## Test plan
- [x] YAML valide
- [ ] Run réel après merge de #41 sur main