### PR TITLE
fix(ci): use valid v-prefixed tag for trivy-action

### DIFF
--- a/.github/workflows/sample-app-build.yml
+++ b/.github/workflows/sample-app-build.yml
@@ -68,7 +68,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.semver.outputs.new_version }}
           format: table


### PR DESCRIPTION
## Problème
Le run de la pipeline échoue dès la résolution des actions :
`Unable to resolve action aquasecurity/trivy-action@0.28.0, unable to find version 0.28.0`

Le tag publié est `v0.28.0` (préfixe `v`), pas `0.28.0`. Bug préexistant qui bloque tout le job avant exécution.

## Fix
`aquasecurity/trivy-action@0.28.0` → `@v0.28.0`.

## Test plan
- [x] Tag vérifié comme existant via l'API GitHub
- [ ] Run vert sur main après merge