### PR TITLE
fix(ci): bump trivy-action to v0.36.0

### DIFF
--- a/.github/workflows/sample-app-build.yml
+++ b/.github/workflows/sample-app-build.yml
@@ -68,7 +68,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.semver.outputs.new_version }}
           format: table


### PR DESCRIPTION
## Problème
`trivy-action@v0.28.0` est une action composite qui pin en interne `aquasecurity/setup-trivy@v0.2.1` — un tag qui n'existe plus, donc la résolution transitive échoue (`unable to find version v0.2.1`) et le job échoue dès le setup.

## Fix
Bump vers `v0.36.0`, qui pin `setup-trivy` sur un SHA équivalent à `v0.2.6` (tag existant). Vérifié via l'action.yaml de la version.

## Test plan
- [ ] Run vert sur main après merge