### PR TITLE
fix(ci): lowercase image repository name for GHCR

### DIFF
--- a/.github/workflows/sample-app-build.yml
+++ b/.github/workflows/sample-app-build.yml
@@ -14,7 +14,9 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/sample-app
+  # IMAGE_NAME is derived (lowercased) at runtime — see the "Resolve image name"
+  # step. GHCR/Docker require the repository path to be lowercase, but
+  # ${{ github.repository }} preserves the original casing.
   CHART_PATH: ./helm/sample-app
 
 jobs:
@@ -28,6 +30,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history is required to compute the semver bump
+
+      - name: Resolve image name (lowercase)
+        run: |
+          echo "IMAGE_NAME=$(echo '${{ github.repository }}/sample-app' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Compute next semver tag from conventional commits
         id: semver


### PR DESCRIPTION
## Problème
`buildx failed: invalid tag "ghcr.io/T-CLO-902-KubeQuest/KubeQuest/sample-app:0.0.1": repository name must be lowercase`

`IMAGE_NAME` était dérivé de `${{ github.repository }}` (casse d'origine) dans le bloc `env:`. Docker/GHCR exigent un chemin de dépôt en minuscules. Bug préexistant, révélé maintenant que le pipeline atteint l'étape de build.

## Fix
Étape `Resolve image name (lowercase)` qui calcule `IMAGE_NAME` lowercased dans `$GITHUB_ENV` après le checkout. Toutes les étapes image (metadata, build, scan, push) la consomment via `${{ env.IMAGE_NAME }}`. L'étape de release du chart faisait déjà son propre lowercasing.

## Test plan
- [x] YAML valide
- [ ] Run vert sur main après merge