### PR TITLE
fix(sample-app): patch base image to reduce CVE exposure

### DIFF
--- a/sample-app/Dockerfile
+++ b/sample-app/Dockerfile
@@ -1,10 +1,16 @@
-# Utilisez une image Docker officielle pour PHP 7.4 avec Apache
-FROM php:8.2.8-apache
+# Image Docker officielle PHP 8.2 avec Apache.
+# Tag mineur (non figé sur un patch) pour récupérer les correctifs de sécurité.
+FROM php:8.2-apache
 
 # Installez les extensions PHP nécessaires
 RUN docker-php-ext-install pdo_mysql
 
-RUN apt-get update && apt-get install -y git unzip p7zip-full
+# Patche les paquets OS de l'image de base, puis installe les dépendances.
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends git unzip p7zip-full \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Installez Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
## Problème
Le scan Trivy de la pipeline échoue : **1256 vulnérabilités (27 CRITICAL, 1229 HIGH)** dans l'image, en grande partie corrigeables (`fixed`). Cause : l'image de base était figée sur un vieux patch `php:8.2.8-apache` (mi-2023).

## Fix
- `FROM php:8.2.8-apache` → `php:8.2-apache` (tag mineur, récupère le dernier patch 8.2).
- Ajout de `apt-get upgrade -y` pour patcher les paquets OS au-delà de l'image de base.
- `--no-install-recommends` + nettoyage du cache apt pour réduire la surface.
- Commentaire d'en-tête corrigé (mentionnait PHP 7.4).

## Test plan
- [ ] Scan Trivy passant (ou chute nette du nombre de CVE) sur main après merge