### PR TITLE
17 deploy database helm chart

### DIFF
--- a/argocd/apps/local-path-provisioner/application.yaml
+++ b/argocd/apps/local-path-provisioner/application.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: local-path-provisioner
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/T-CLO-902-KubeQuest/KubeQuest.git
+    targetRevision: main
+    path: k8s/local-path-provisioner
+    directory:
+      include: "local-path-provisioner.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: local-path-storage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/apps/mysql/application.yaml
+++ b/argocd/apps/mysql/application.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mysql
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/T-CLO-902-KubeQuest/KubeQuest.git
+    targetRevision: main
+    path: k8s/mysql
+    directory:
+      include: "mysql.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mysql
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/apps/mysql/application.yaml
+++ b/argocd/apps/mysql/application.yaml
@@ -14,7 +14,7 @@ spec:
     targetRevision: main
     path: k8s/mysql
     directory:
-      include: "mysql.yaml"
+      include: "{mysql.yaml,backup.yaml}"
   destination:
     server: https://kubernetes.default.svc
     namespace: mysql

--- a/helm/mysql/values.yaml
+++ b/helm/mysql/values.yaml
@@ -1,0 +1,19 @@
+architecture: "standalone"
+auth:
+  database: "laravel"
+  username: "laravel"
+  existingSecret: "mysql-credentials"
+primary:
+  persistence:
+    enabled: true
+    size: 5Gi
+    storageClass: "local-path"
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+image:
+  repository: "bitnamilegacy/mysql"

--- a/k8s/local-path-provisioner/local-path-provisioner.yaml
+++ b/k8s/local-path-provisioner/local-path-provisioner.yaml
@@ -1,0 +1,163 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-path-provisioner-role
+  namespace: local-path-storage
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  namespace: local-path-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+        - name: local-path-provisioner
+          image: docker.io/rancher/local-path-provisioner:v0.0.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - local-path-provisioner
+            - --debug
+            - start
+            - --config
+            - /etc/config/config.json
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config/
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_MOUNT_PATH
+              value: /etc/config/
+      volumes:
+        - name: config-volume
+          configMap:
+            name: local-path-config
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+    {
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["/opt/local-path-provisioner"]
+            }
+            ]
+    }
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - name: helper-pod
+        image: docker.io/library/busybox
+        imagePullPolicy: IfNotPresent

--- a/k8s/mysql/README.md
+++ b/k8s/mysql/README.md
@@ -84,5 +84,36 @@ Connection from inside the cluster: host `mysql.mysql.svc.cluster.local`, port
 `3306`.
 
 ## Backup / restore
-> **TODO** — strategy to be implemented (Issue #17 acceptance criterion). Will
-> document a tested backup and restore procedure here.
+Logical backups via `mysqldump` (`k8s/mysql/backup.yaml`). A `VolumeSnapshot`
+approach is not available: `local-path` has no CSI snapshot capability.
+
+### Backup (automated)
+A `CronJob` (`mysql-backup`, daily at 02:00) runs `mysqldump --single-transaction`
+against the `laravel` database and writes a timestamped `.sql` dump to a dedicated
+`mysql-backups` PVC mounted at `/backups`. The root password is read from the
+`mysql-credentials` Secret — never hard-coded. A second `CronJob`
+(`mysql-backup-cleanup`, daily at 03:00) prunes dumps older than 7 days.
+
+Trigger an on-demand backup without waiting for the schedule:
+```sh
+kubectl create job --from=cronjob/mysql-backup mysql-backup-manual -n mysql
+```
+
+### Restore
+Replay the latest dump into the database with a one-off pod that mounts the
+backup PVC and pulls the root password from the Secret:
+```sh
+kubectl run -n mysql mysql-restore --rm -it --restart=Never \
+  --image=docker.io/bitnamilegacy/mysql:8.0.37-debian-12-r2 \
+  --overrides='{"apiVersion":"v1","spec":{"containers":[{"name":"c","image":"docker.io/bitnamilegacy/mysql:8.0.37-debian-12-r2","command":["/bin/sh","-c"],"args":["mysql -h mysql -u root -p\"$MYSQL_ROOT_PASSWORD\" laravel < $(ls -t /backups/*.sql | head -1)"],"env":[{"name":"MYSQL_ROOT_PASSWORD","valueFrom":{"secretKeyRef":{"name":"mysql-credentials","key":"mysql-root-password"}}}],"volumeMounts":[{"name":"v","mountPath":"/backups"}]}],"volumes":[{"name":"v","persistentVolumeClaim":{"claimName":"mysql-backups"}}]}}'
+```
+To restore a specific dump instead of the latest, replace the `$(ls -t ...)`
+expression with the explicit `/backups/laravel-<date>.sql` path.
+
+> Tested: insert a row → run the backup CronJob → drop the table → restore →
+> the row is back. Verified on the `kubequest-aws` cluster.
+
+> Production note: dumps live on a `local-path` PVC, i.e. the node's local disk —
+> if the node is lost, both data and backups are lost. The robust evolution is to
+> push dumps off-cluster (e.g. an S3 bucket), which requires AWS credentials in a
+> Secret.

--- a/k8s/mysql/README.md
+++ b/k8s/mysql/README.md
@@ -1,0 +1,88 @@
+# MySQL Database
+
+## Overview
+MySQL 8.0 is the persistent datastore for the Laravel `sample-app` (Issue #17).
+The subject mandates an **official Helm chart** for the database (not a hand-rolled
+manifest), with persistent storage, secrets kept out of Git, and a tested
+backup/restore procedure. It runs as a single-node StatefulSet
+(`architecture: standalone`) — enough for this workload, and it keeps backups
+simple.
+
+## Design: vendored manifest
+Like Cilium, Argo CD, cert-manager and Headlamp, MySQL is installed from a
+manifest checked into the repo (`k8s/mysql/mysql.yaml`), rendered with
+`helm template` — never `helm install` (no Helm release state on the cluster).
+Every change is a reviewable diff alongside its source values
+(`helm/mysql/values.yaml`).
+
+### Regenerating the manifest
+```sh
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update bitnami
+helm template mysql bitnami/mysql \
+  --version 10.3.0 \
+  --namespace mysql \
+  --values helm/mysql/values.yaml \
+  > k8s/mysql/mysql.yaml
+```
+Pinned chart version: **10.3.0** (app version MySQL **8.0.37**), chosen to match
+the `mysql:8.0` the app's `docker-compose` expects. Bump it here and in the
+command above, then commit the regenerated manifest with the values change.
+
+> **Image registry — `bitnamilegacy`.** Bitnami moved its free Docker Hub images
+> out of `docker.io/bitnami` (the pinned tag now returns `manifest unknown`).
+> `helm/mysql/values.yaml` overrides `image.repository` to `bitnamilegacy/mysql`,
+> which still pulls. These images are frozen and no longer receive security
+> updates — **technical debt**. Production fix: mirror the image into a registry
+> we control, or move to Bitnami Secure Images.
+
+## Persistence
+The chart requests a `PersistentVolumeClaim` (`primary.persistence`, 5Gi) bound to
+the **`local-path`** StorageClass provisioned by
+`argocd/apps/local-path-provisioner`. That StorageClass uses
+`reclaimPolicy: Retain`, so the underlying volume **survives deletion of the
+PVC/pod** — the persistence requirement of the issue. The StatefulSet guarantees
+the pod re-attaches to the same volume across restarts.
+
+> Production note: `local-path` stores data on the node's local disk, so the
+> volume is tied to one node. The cloud-native evolution is the AWS EBS CSI
+> driver (network-attached volumes), which requires IAM wiring not yet present in
+> the infra.
+
+### Resource limits
+The node is small (2 vCPU / 4 GB, shared with Argo CD & co.) and the dataset is
+tiny, so MySQL is capped rather than left to burst:
+`requests` 250m/256Mi, `limits` 500m/512Mi. If the pod is `OOMKilled` at startup,
+raise the memory limit to 768Mi–1Gi.
+
+## Credentials (Secret, not committed)
+The chart consumes an **existing** Secret (`auth.existingSecret: mysql-credentials`)
+instead of generating one, so no password is ever rendered into the committed
+manifest. The Secret is created out of band, once, with generated values:
+```sh
+kubectl create namespace mysql
+kubectl create secret generic mysql-credentials -n mysql \
+  --from-literal=mysql-root-password="$(openssl rand -base64 24)" \
+  --from-literal=mysql-password="$(openssl rand -base64 24)"
+```
+The key names (`mysql-root-password`, `mysql-password`) are exactly those the
+StatefulSet reads — do not rename them. The `mysql-password` is the password of
+the application user `laravel` (database `laravel`); the app will be wired to
+these in the app-deployment issue.
+
+> GitOps evolution: replace the manual Secret with **Sealed Secrets** (encrypted
+> object committable to Git, decrypted in-cluster), shareable with Dex's secret.
+
+## Deployment
+Managed by GitOps: the `Application` at `argocd/apps/mysql/application.yaml`
+(sync-wave `0`) is picked up by the root app-of-apps and synced automatically.
+The storage layer (`local-path-provisioner`, sync-wave `-1`) syncs first so the
+PVC can bind. Create the Secret **before** the sync to avoid a transient
+CrashLoop. No manual `kubectl apply`.
+
+Connection from inside the cluster: host `mysql.mysql.svc.cluster.local`, port
+`3306`.
+
+## Backup / restore
+> **TODO** — strategy to be implemented (Issue #17 acceptance criterion). Will
+> document a tested backup and restore procedure here.

--- a/k8s/mysql/backup.yaml
+++ b/k8s/mysql/backup.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-backups
+  namespace: mysql
+spec:
+  accessModes: [ ReadWriteOnce ]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: local-path
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mysql-backup
+  namespace: mysql
+spec:
+  schedule: "0 2 * * *" # Every day at 2 AM
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: mysql-backup
+              image: docker.io/bitnamilegacy/mysql:8.0.37-debian-12-r2
+              env:
+                - name: MYSQL_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: mysql-credentials
+                      key: mysql-root-password
+              command: ["/bin/sh", "-c"]
+              args:
+                - mysqldump --single-transaction -h mysql -u root -p"$MYSQL_ROOT_PASSWORD" laravel > /backups/laravel-$(date +%F-%H%M%S).sql
+              volumeMounts:
+                - name: mysql-backups
+                  mountPath: /backups
+          restartPolicy: OnFailure
+          volumes:
+            - name: mysql-backups
+              persistentVolumeClaim:
+                claimName: mysql-backups
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mysql-backup-cleanup
+  namespace: mysql
+spec:
+  schedule: "0 3 * * *" # Every day at 3 AM
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: mysql-backup-cleanup
+              image: docker.io/bitnamilegacy/mysql:8.0.37-debian-12-r2
+              command: ["/bin/sh", "-c"]
+              args:
+                - find /backups -type f -name "*.sql" -mtime +7 -delete
+              volumeMounts:
+                - name: mysql-backups
+                  mountPath: /backups
+          restartPolicy: OnFailure
+          volumes:
+            - name: mysql-backups
+              persistentVolumeClaim:
+                claimName: mysql-backups

--- a/k8s/mysql/mysql.yaml
+++ b/k8s/mysql/mysql.yaml
@@ -1,0 +1,374 @@
+---
+# Source: mysql/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: mysql
+  namespace: "mysql"
+  labels:
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/version: 8.0.37
+    helm.sh/chart: mysql-10.3.0
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: mysql
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/version: 8.0.37
+      helm.sh/chart: mysql-10.3.0
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 3306
+        - port: 3306
+---
+# Source: mysql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+  namespace: "mysql"
+  labels:
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/version: 8.0.37
+    helm.sh/chart: mysql-10.3.0
+automountServiceAccountToken: false
+secrets:
+  - name: mysql-credentials
+---
+# Source: mysql/templates/primary/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql
+  namespace: "mysql"
+  labels:
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/version: 8.0.37
+    helm.sh/chart: mysql-10.3.0
+    app.kubernetes.io/component: primary
+data:
+  my.cnf: |-
+    [mysqld]
+    default_authentication_plugin=mysql_native_password
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/bitnami/mysql
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    port=3306
+    mysqlx=0
+    mysqlx_port=33060
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    datadir=/bitnami/mysql/data
+    tmpdir=/opt/bitnami/mysql/tmp
+    max_allowed_packet=16M
+    bind-address=*
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+    log-error=/opt/bitnami/mysql/logs/mysqld.log
+    character-set-server=UTF8
+    slow_query_log=0
+    long_query_time=10.0
+    
+    [client]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    default-character-set=UTF8
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    
+    [manager]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+---
+# Source: mysql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-headless
+  namespace: "mysql"
+  labels:
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/version: 8.0.37
+    helm.sh/chart: mysql-10.3.0
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+  selector:
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: primary
+---
+# Source: mysql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: "mysql"
+  labels:
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/version: 8.0.37
+    helm.sh/chart: mysql-10.3.0
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: mysql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: primary
+---
+# Source: mysql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: "mysql"
+  labels:
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/version: 8.0.37
+    helm.sh/chart: mysql-10.3.0
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  podManagementPolicy: ""
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: mysql
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: primary
+  serviceName: mysql
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/configuration: 65bd0f74f6f6fd65fb615d27bb2e82021eeb13be67c53148f59dc175d97203b0
+      labels:
+        app.kubernetes.io/instance: mysql
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/version: 8.0.37
+        helm.sh/chart: mysql-10.3.0
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: mysql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: mysql
+                    app.kubernetes.io/name: mysql
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
+      initContainers:
+        - name: preserve-logs-symlinks
+          image: docker.io/bitnamilegacy/mysql:8.0.37-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources: 
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              #!/bin/bash
+
+              . /opt/bitnami/scripts/libfs.sh
+              # We copy the logs folder because it has symlinks to stdout and stderr
+              if ! is_dir_empty /opt/bitnami/mysql/logs; then
+                cp -r /opt/bitnami/mysql/logs /emptydir/app-logs-dir
+              fi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /emptydir
+      containers:
+        - name: mysql
+          image: docker.io/bitnamilegacy/mysql:8.0.37-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-credentials
+                  key: mysql-root-password
+            - name: MYSQL_USER
+              value: "laravel"
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-credentials
+                  key: mysql-password
+            - name: MYSQL_PORT
+              value: "3306"
+            - name: MYSQL_DATABASE
+              value: "laravel"
+          envFrom:
+          ports:
+            - name: mysql
+              containerPort: 3306
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
+                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
+                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+                  fi
+                  mysqladmin status -uroot -p"${password_aux}"
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
+                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
+                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+                  fi
+                  mysqladmin ping -uroot -p"${password_aux}"
+          startupProbe:
+            failureThreshold: 10
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
+                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
+                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+                  fi
+                  mysqladmin ping -uroot -p"${password_aux}"
+          resources: 
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/mysql
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/mysql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/mysql/tmp
+              subPath: app-tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/mysql/logs
+              subPath: app-logs-dir
+            - name: config
+              mountPath: /opt/bitnami/mysql/conf/my.cnf
+              subPath: my.cnf
+      volumes:
+        - name: config
+          configMap:
+            name: mysql
+        - name: empty-dir
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/instance: mysql
+          app.kubernetes.io/name: mysql
+          app.kubernetes.io/component: primary
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "5Gi"
+        storageClassName: local-path


### PR DESCRIPTION
This pull request introduces a production-ready, GitOps-managed MySQL 8.0 database deployment for the Laravel `sample-app`, using the official Bitnami Helm chart rendered to a manifest. It includes secure credential management (with passwords stored in Kubernetes Secrets, not in Git), persistent storage via the `local-path-provisioner`, and a robust backup/restore solution using Kubernetes CronJobs. The deployment is fully automated and managed by Argo CD, ensuring reproducibility and reviewability.

The most important changes are:

**MySQL Application Deployment (GitOps, Security, Persistence):**
* Added an Argo CD `Application` manifest (`argocd/apps/mysql/application.yaml`) to manage the MySQL deployment, with automated sync, namespace creation, and referencing the rendered Helm manifest for reproducibility.
* Created a Helm values file (`helm/mysql/values.yaml`) specifying a single-node (`standalone`) MySQL setup, persistent storage (5Gi, `local-path`), resource limits, and use of an existing Secret for credentials.
* Added a detailed README (`k8s/mysql/README.md`) explaining the design, credential handling, persistence, backup/restore, and operational notes for the MySQL deployment.

**Persistent Storage Provisioning:**
* Added a full manifest for `local-path-provisioner` (`k8s/local-path-provisioner/local-path-provisioner.yaml`) and an Argo CD `Application` to manage it (`argocd/apps/local-path-provisioner/application.yaml`), providing a default StorageClass for MySQL PVCs. [[1]](diffhunk://#diff-763b624f66718459a735f49b59858b4417f4331a672390c504f303d9793b63a2R1-R163) [[2]](diffhunk://#diff-13d121b73b61d8e861676c9dcf444145ee42f80302d49540b2887d125b095290R1-R26)

**Backup and Restore Automation:**
* Introduced a backup solution (`k8s/mysql/backup.yaml`) with a PVC for backup storage and two CronJobs: one for daily logical backups using `mysqldump`, and another for automated cleanup of old backups, ensuring data can be restored and is retained for at least 7 days.

**MySQL Deployment Manifest (Helm-rendered):**
* Added the rendered MySQL manifest (`k8s/mysql/mysql.yaml`), including StatefulSet, Services, ConfigMap, ServiceAccount, NetworkPolicy, and PVC templates, all configured for secure, persistent, minimal, and resource-capped operation.