### PR TITLE
fix(argocd): align sample-app DB to the MySQL-provisioned laravel db/user

### DIFF
--- a/argocd/apps/sample-app/application.yaml
+++ b/argocd/apps/sample-app/application.yaml
@@ -37,6 +37,13 @@ spec:
           # Read APP_KEY / DB_PASSWORD from this pre-existing cluster Secret so
           # no secret material is committed to Git.
           existingSecret: sample-app
+        db:
+          # Match the database/user the MySQL chart actually provisions
+          # (helm/mysql/values.yaml: auth.database/username = "laravel").
+          # The password lives in the existingSecret above (copied from
+          # mysql/mysql-credentials).
+          database: laravel
+          username: laravel
   destination:
     server: https://kubernetes.default.svc
     namespace: sample-app


### PR DESCRIPTION
## Quoi

Découvert en créant le Secret en cluster : le chart MySQL provisionne la base/utilisateur **`laravel`** (`helm/mysql/values.yaml` → `auth.database/username`), alors que le chart sample-app pointait par défaut sur `app_database`/`app_user`. L'app n'aurait pas pu se connecter.

Cette PR surcharge `db.database` et `db.username` à `laravel` dans l'Application ArgoCD. Le mot de passe reste hors-Git (Secret `sample-app`, copié depuis `mysql/mysql-credentials`).

## Suite de #65.