### PR TITLE
fix(argocd): pin sample-app to chart 0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ terraform.rc
 .idea/**
 
 ansible/inventory.local.yml
+
+# Local git worktrees
+.worktrees/

--- a/argocd/apps/sample-app/application.yaml
+++ b/argocd/apps/sample-app/application.yaml
@@ -30,7 +30,7 @@ spec:
     repoURL: ghcr.io/t-clo-902-kubequest/kubequest/charts
     chart: sample-app
     # Pinned semver — bump to match the chart/image released by CI.
-    targetRevision: 0.0.1
+    targetRevision: 0.1.0
     helm:
       valuesObject:
         app:


### PR DESCRIPTION
## Quoi

L'Application pointait sur le chart `0.0.1`, antérieur à l'ajout de `app.existingSecret` / TLS / host `epitech.beer` — le sync ArgoCD échouait sur `app.key is required`. La CI a publié `0.1.0` (qui contient ces changements) quand les modifs `helm/sample-app/**` de #65 ont atterri sur `main`. Cette PR aligne `targetRevision` sur `0.1.0`.

Ajoute aussi `.worktrees/` au `.gitignore`.

Suite de #65 / #66. (Remplace #67, fermée car commit pollué.)