### PR TITLE
docs(adr): record the mysql network policy and backup hardening decision

### DIFF
--- a/adr/0002-mysql-network-policy-and-backup-hardening.md
+++ b/adr/0002-mysql-network-policy-and-backup-hardening.md
@@ -1,0 +1,80 @@
+# 0002 - Durcissement de la NetworkPolicy et des backups MySQL
+
+- Statut : Accepted
+- Date : 2026-06-19
+- Décideurs : équipe KubeQuest
+- PR : [#64](https://github.com/T-CLO-902-KubeQuest/KubeQuest/pull/64)
+
+## Contexte
+
+Le déploiement MySQL (#60) installe le chart Helm Bitnami `mysql` (rendu en
+manifest vendoré, `k8s/mysql/mysql.yaml`) plus un dispositif de backup logique
+par `CronJob` (`k8s/mysql/backup.yaml`). La review post-merge a relevé trois
+écarts de robustesse/sécurité :
+
+- La `NetworkPolicy` rendue par défaut autorisait **tout l'egress**
+  (`egress: - {}`), alors qu'une base de données n'a aucune raison d'initier des
+  connexions sortantes arbitraires.
+- Les `CronJob` de backup et de purge n'avaient ni `securityContext`, ni
+  `resources`, ni garde-fous d'exécution (concurrence, rétention d'historique),
+  contrairement au `StatefulSet` MySQL déjà durci.
+- Le backup écrivait directement dans le fichier `.sql` final ; un dump
+  interrompu laissait un fichier partiel que la procédure de restore
+  (`ls -t | head -1`) aurait sélectionné comme « dernier dump valide ».
+
+## Décision
+
+### NetworkPolicy
+
+Restreindre l'egress via les valeurs Helm (et non en éditant le manifest rendu,
+qui reste régénérable) : `networkPolicy.allowExternalEgress: false` dans
+`helm/mysql/values.yaml`. Le chart génère alors un egress limité à la résolution
+**DNS** (port 53) et au **trafic intra-cluster**, au lieu d'autoriser toutes les
+destinations.
+
+L'**ingress est volontairement laissé port-only** (`allowExternal: true`) :
+le port 3306 reste accessible depuis n'importe quel pod. Le consommateur
+`sample-app` n'est pas encore déployé, donc son label de pod n'est pas connu ;
+restreindre l'ingress maintenant bloquerait son futur déploiement.
+
+### Backups
+
+Aligner les deux `CronJob` (`mysql-backup`, `mysql-backup-cleanup`) sur le
+durcissement du `StatefulSet` :
+
+- `securityContext` : `runAsNonRoot`, `runAsUser/Group: 1001`,
+  `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`,
+  `seccompProfile: RuntimeDefault`.
+- `resources` (requests/limits) bornées.
+- Garde-fous d'exécution : `concurrencyPolicy: Forbid`,
+  `successfulJobsHistoryLimit`/`failedJobsHistoryLimit: 3`,
+  `startingDeadlineSeconds: 300`.
+
+Rendre le backup **atomique** : écrire le dump dans un fichier `.tmp` puis le
+renommer (`mv`) uniquement en cas de succès, pour qu'un dump interrompu ne laisse
+jamais de `.sql` partiel exploitable par le restore.
+
+## Alternatives envisagées
+
+- **Restreindre aussi l'ingress par label dès maintenant** : rejeté tant que
+  `sample-app` n'est pas déployé — on bloquerait un consommateur dont le label
+  est inconnu. À traiter dans l'issue de déploiement de l'application.
+- **Éditer directement le bloc `NetworkPolicy` dans `mysql.yaml`** : rejeté, le
+  manifest est rendu par `helm template` et doit rester régénérable (cf.
+  `k8s/mysql/README.md`). Le changement passe donc par `values.yaml`.
+
+## Conséquences
+
+### Positives
+
+- Surface réseau réduite : MySQL ne peut plus initier d'egress arbitraire.
+- Pods de backup non privilégiés et bornés en ressources, cohérents avec le
+  reste du déploiement.
+- Plus de risque de restaurer un dump tronqué.
+
+### Négatives / points d'attention
+
+- L'ingress reste ouvert en port-only : **à resserrer par label** une fois
+  `sample-app` déployé.
+- Toute régénération future de `mysql.yaml` doit conserver le bloc
+  `networkPolicy` dans `values.yaml`, sinon l'egress redevient permissif.

--- a/adr/0002-mysql-network-policy-and-backup-hardening.md
+++ b/adr/0002-mysql-network-policy-and-backup-hardening.md
@@ -3,7 +3,7 @@
 - Statut : Accepted
 - Date : 2026-06-19
 - Décideurs : équipe KubeQuest
-- PR : [#64](https://github.com/T-CLO-902-KubeQuest/KubeQuest/pull/64)
+- PR : [#69](https://github.com/T-CLO-902-KubeQuest/KubeQuest/pull/69)
 
 ## Contexte
 

--- a/adr/README.md
+++ b/adr/README.md
@@ -17,3 +17,4 @@ contexte et ses conséquences.
 | ADR | Titre | Statut |
 | --- | --- | --- |
 | [0001](0001-migrate-sample-app-to-laravel-12.md) | Migration de la sample-app vers Laravel 12 | Accepted |
+| [0002](0002-mysql-network-policy-and-backup-hardening.md) | Durcissement de la NetworkPolicy et des backups MySQL | Accepted |

--- a/k8s/mysql/README.md
+++ b/k8s/mysql/README.md
@@ -83,15 +83,6 @@ CrashLoop. No manual `kubectl apply`.
 Connection from inside the cluster: host `mysql.mysql.svc.cluster.local`, port
 `3306`.
 
-## Network policy
-The chart renders a `NetworkPolicy` (`networkPolicy.enabled: true` in
-`helm/mysql/values.yaml`). Egress is restricted (`allowExternalEgress: false`):
-only DNS resolution and intra-cluster pod traffic are allowed, instead of the
-chart default that permits all destinations. Ingress is left port-only
-(`allowExternal: true`): port `3306` is reachable from any pod, because the
-`sample-app` consumer is not deployed yet. **Tighten ingress to the app's pod
-label in the app-deployment issue**, once that label is known.
-
 ## Backup / restore
 Logical backups via `mysqldump` (`k8s/mysql/backup.yaml`). A `VolumeSnapshot`
 approach is not available: `local-path` has no CSI snapshot capability.


### PR DESCRIPTION
Documente dans un ADR la décision de durcissement MySQL.

Le durcissement lui-même (egress restreint, garde-fous des CronJobs, backup atomique, newlines) a déjà été mergé sur `main` via #65/#66 — la PR #64 (qui le portait aussi) est donc devenue redondante et est fermée au profit de celle-ci.

## Contenu
- `adr/0002-mysql-network-policy-and-backup-hardening.md` : décision, contexte, alternatives, conséquences (format MADR, comme 0001).
- `adr/README.md` : entrée d'index ajoutée.
- `k8s/mysql/README.md` : section opérationnelle « Network policy » retirée — le « pourquoi » vit désormais dans l'ADR.
