### PR TITLE
fix(ci): build sample-app image for linux/arm64

### DIFF
--- a/.github/workflows/sample-app-build.yml
+++ b/.github/workflows/sample-app-build.yml
@@ -44,6 +44,13 @@ jobs:
           release_branches: main
           dry_run: true # we tag manually below, after a successful push
 
+      # The cluster runs on arm64 (AWS Graviton) nodes, so the image must be
+      # built for linux/arm64. The GitHub runner is amd64, hence QEMU emulation.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -69,6 +76,7 @@ jobs:
         with:
           context: ./sample-app
           load: true
+          platforms: linux/arm64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.semver.outputs.new_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -88,6 +96,7 @@ jobs:
         with:
           context: ./sample-app
           push: true
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Quoi

Les nœuds du cluster sont en **arm64** (AWS Graviton), mais la CI ne buildait l'image que pour l'amd64 du runner → pods en `ImagePullBackOff` (`no match for platform in manifest`).

Ajoute QEMU et cible `linux/arm64` dans les deux étapes de build (scan + push).

## Après merge

Le workflow ne se déclenche pas sur les changements de `.github/**` : il faut le lancer manuellement (`workflow_dispatch`) pour republier l'image. La CI bumpera le semver → il faudra re-pinner l'Application ArgoCD sur la nouvelle version.

Suite de #65 / #66 / #68.