### PR TITLE
feat(ci): native multi-arch build for sample-app image

### DIFF
--- a/.github/workflows/sample-app-build.yml
+++ b/.github/workflows/sample-app-build.yml
@@ -14,17 +14,16 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  # IMAGE_NAME is derived (lowercased) at runtime — see the "Resolve image name"
-  # step. GHCR/Docker require the repository path to be lowercase, but
-  # ${{ github.repository }} preserves the original casing.
   CHART_PATH: ./helm/sample-app
 
 jobs:
-  build-scan-publish:
+  # Compute everything shared by the per-arch builds once, so both architectures
+  # publish under the same image name and semver.
+  prepare:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # needed to push the semver tag
-      packages: write # needed to push the image to GHCR
+    outputs:
+      version: ${{ steps.semver.outputs.new_version }}
+      image_name: ${{ steps.image.outputs.name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,8 +31,11 @@ jobs:
           fetch-depth: 0 # full history is required to compute the semver bump
 
       - name: Resolve image name (lowercase)
+        id: image
+        # GHCR/Docker require a lowercase repository path, but
+        # ${{ github.repository }} preserves the original casing.
         run: |
-          echo "IMAGE_NAME=$(echo '${{ github.repository }}/sample-app' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          echo "name=$(echo '${{ github.repository }}/sample-app' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Compute next semver tag from conventional commits
         id: semver
@@ -42,14 +44,110 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
           release_branches: main
-          dry_run: true # we tag manually below, after a successful push
+          dry_run: true # the tag is pushed by the publish job, after a successful push
 
-      # The cluster runs on arm64 (AWS Graviton) nodes, so the image must be
-      # built for linux/arm64. The GitHub runner is amd64, hence QEMU emulation.
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+  # One native build per architecture: amd64 on the x86 runner, arm64 on the
+  # GitHub-hosted Graviton runner. No QEMU emulation. Each job scans its own
+  # image, then pushes it by digest (no tag) so the publish job can assemble a
+  # multi-arch manifest list from the per-arch digests.
+  build:
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      packages: write # needed to push the image to GHCR
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          platforms: arm64
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image (load locally for scanning)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./sample-app
+          load: true
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.REGISTRY }}/${{ needs.prepare.outputs.image_name }}:${{ needs.prepare.outputs.version }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ needs.prepare.outputs.image_name }}:${{ needs.prepare.outputs.version }}-${{ matrix.arch }}
+          format: table
+          exit-code: "1" # fail the pipeline on findings
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          vuln-type: os,library
+
+      - name: Push image by digest
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./sample-app
+          platforms: ${{ matrix.platform }}
+          # Push by digest only; the multi-arch tags are applied by the publish
+          # job's manifest list. outputs.push-by-digest writes no tag.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ needs.prepare.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the multi-arch manifest list from the per-arch digests, tag the git
+  # commit, and release the matching Helm chart.
+  publish:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to push the semver tag
+      packages: write # needed to push the manifest list and chart to GHCR
+    env:
+      IMAGE_NAME: ${{ needs.prepare.outputs.image_name }}
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -67,40 +165,22 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ steps.semver.outputs.new_version }}
+            type=raw,value=${{ env.VERSION }}
             type=raw,value=latest
             type=sha,format=short
 
-      - name: Build image (load locally for scanning)
-        uses: docker/build-push-action@v6
-        with:
-          context: ./sample-app
-          load: true
-          platforms: linux/arm64
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.semver.outputs.new_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create multi-arch manifest list
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          # One -t per desired tag, sourcing all per-arch digests.
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.semver.outputs.new_version }}
-          format: table
-          exit-code: "1" # fail the pipeline on findings
-          ignore-unfixed: true
-          severity: CRITICAL,HIGH
-          vuln-type: os,library
-
-      - name: Push image to GHCR
-        uses: docker/build-push-action@v6
-        with:
-          context: ./sample-app
-          push: true
-          platforms: linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}"
 
       - name: Create and push semver git tag
         uses: mathieudutour/github-tag-action@v6.2
@@ -108,7 +188,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
           release_branches: main
-          custom_tag: ${{ steps.semver.outputs.new_version }}
+          custom_tag: ${{ env.VERSION }}
           tag_prefix: v
 
       # --- Helm chart release (same semver as the image just published) ---
@@ -117,12 +197,9 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Package and push Helm chart to GHCR
-        env:
-          VERSION: ${{ steps.semver.outputs.new_version }}
         run: |
           set -euo pipefail
           # GHCR requires a lowercase repository path.
-          OWNER_LC="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
           REPO_LC="$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
           CHART_REF="oci://ghcr.io/${REPO_LC}/charts"
 

--- a/adr/0003-native-multiarch-image-build.md
+++ b/adr/0003-native-multiarch-image-build.md
@@ -1,0 +1,71 @@
+# 0003 - Build multi-arch natif de l'image sample-app
+
+- Statut : Accepted
+- Date : 2026-06-19
+- Décideurs : équipe KubeQuest
+- PR : [#71](https://github.com/T-CLO-902-KubeQuest/KubeQuest/pull/71)
+
+## Contexte
+
+Le cluster tourne sur des nœuds **arm64** (AWS Graviton), mais le workflow
+`sample-app-build.yml` ne buildait l'image que pour l'architecture du runner
+GitHub (amd64). Les pods restaient en `ImagePullBackOff` avec l'erreur
+`no match for platform in manifest` : l'image publiée n'avait pas de variante
+arm64.
+
+Un premier correctif (#70) a ajouté **QEMU** pour émuler arm64 sur le runner
+amd64. Fonctionnel, mais l'émulation est lente et fragile (composer / build PHP
+sous QEMU). On a cherché une approche native.
+
+GitHub fournit désormais des **runners ARM64 hébergés** (`ubuntu-24.04-arm`,
+Graviton), **gratuits sur les dépôts publics** — ce qui est notre cas. On peut
+donc builder chaque architecture sur son propre runner natif, sans émulation.
+
+## Décision
+
+Refondre le workflow en **multi-arch natif par matrice**, en trois jobs :
+
+1. **`prepare`** — calcule une seule fois la version semver (dry-run) et le nom
+   d'image (lowercased), exposés en `outputs` pour que les deux builds publient
+   sous la même version.
+2. **`build`** (matrice) — un job natif par architecture :
+   - `linux/amd64` sur `ubuntu-24.04`,
+   - `linux/arm64` sur `ubuntu-24.04-arm`.
+   Chaque job build l'image, la scanne avec **Trivy** (le scan reste bloquant et
+   couvre donc chaque architecture), puis la pousse **par digest**
+   (`push-by-digest=true`, sans tag). Le cache GHA est **scopé par arch**
+   (`scope=${arch}`) pour éviter qu'une arch écrase le cache de l'autre.
+3. **`publish`** — récupère les digests des deux builds et assemble le
+   **manifest list** multi-arch via `docker buildx imagetools create`, en y
+   apposant les tags semver / `latest` / `sha`. Puis tag git et release du chart
+   Helm (version = appVersion = même semver que l'image).
+
+## Alternatives envisagées
+
+- **QEMU (approche #70)** : retenue temporairement, puis remplacée. Émulation
+  lente et moins fiable pour le build PHP/composer ; un seul runner.
+- **Runner self-hosted sur les nœuds Graviton du cluster** : build arm64 natif
+  mais infrastructure à déployer et maintenir (sécurité, mises à jour, capacité).
+  Rejeté tant que les runners ARM hébergés gratuits couvrent le besoin.
+- **arm64 seul (pas de multi-arch)** : suffirait pour le cluster actuel, mais on
+  perd la portabilité amd64 (dev local, futur nœud x86) pour un gain marginal.
+  Le surcoût d'un second job natif parallèle est faible.
+
+## Conséquences
+
+### Positives
+
+- Image **portable** `linux/amd64` + `linux/arm64` ; tourne sur le cluster
+  Graviton et en local x86.
+- Builds **natifs et parallèles** : plus rapides et plus fiables que QEMU ; le
+  temps total du pipeline est celui du job le plus lent, pas la somme.
+- Scan Trivy bloquant conservé, désormais par architecture.
+
+### Négatives / points d'attention
+
+- Dépend de la disponibilité des runners hébergés `ubuntu-24.04-arm` et de la
+  **gratuité sur dépôt public** : passer le dépôt en privé facturerait ces
+  minutes ARM, ou imposerait un runner self-hosted.
+- Pipeline plus complexe (3 jobs, artefacts de digests) qu'un job linéaire.
+- Au premier run d'une arch, son cache GHA est froid → ce build est plus long ;
+  l'écart se résorbe aux runs suivants (cache chaud).

--- a/adr/README.md
+++ b/adr/README.md
@@ -18,3 +18,4 @@ contexte et ses conséquences.
 | --- | --- | --- |
 | [0001](0001-migrate-sample-app-to-laravel-12.md) | Migration de la sample-app vers Laravel 12 | Accepted |
 | [0002](0002-mysql-network-policy-and-backup-hardening.md) | Durcissement de la NetworkPolicy et des backups MySQL | Accepted |
+| [0003](0003-native-multiarch-image-build.md) | Build multi-arch natif de l'image sample-app | Accepted |


### PR DESCRIPTION
## Quoi

Remplace le build arm64 émulé par QEMU (#70) par un **vrai multi-arch avec runners natifs** :

```
prepare ──► build (matrix)                         publish
            ├─ amd64 → ubuntu-24.04      push digest ─┐
            └─ arm64 → ubuntu-24.04-arm  push digest ─┴─► manifest list ──► tag git ──► chart Helm
```

- `prepare` : calcule semver + nom d'image une seule fois (outputs partagés).
- `build` : un job natif par arch (amd64 sur `ubuntu-24.04`, arm64 sur le runner GitHub-hosted `ubuntu-24.04-arm` Graviton). Chaque job scanne son image avec Trivy puis pousse **par digest**.
- `publish` : assemble le manifest list multi-arch (`docker buildx imagetools create`) avec les tags semver/latest/sha, crée le tag git, release le chart Helm.

## Pourquoi

Les nœuds du cluster sont arm64 ; le build natif est plus rapide et fiable que QEMU, et l'image tourne désormais sur amd64 **et** arm64. Runners ARM gratuits car le repo est public.

## Après merge

Lancer le workflow (`workflow_dispatch`) pour publier la nouvelle image multi-arch. La CI bumpera le semver → re-pinner l'Application ArgoCD sur la nouvelle version.

Remplace l'approche QEMU de #70.