### PR TITLE
feat(argocd): track sample-app chart with a semver range

### DIFF
--- a/argocd/apps/sample-app/application.yaml
+++ b/argocd/apps/sample-app/application.yaml
@@ -3,7 +3,8 @@
 # Unlike the other workloads (which sync rendered manifests from this Git repo),
 # this Application installs the Helm chart published to GHCR as an OCI artifact
 # by .github/workflows/sample-app-build.yml. The chart and image share the same
-# semver, so pinning targetRevision pins both.
+# semver, so a targetRevision range tracks both (see the source.targetRevision
+# note below for how new releases roll out automatically).
 #
 # Secrets (APP_KEY, DB_PASSWORD) are NOT passed here — they live in a Secret
 # created out-of-band on the cluster (never committed). The chart's
@@ -29,8 +30,12 @@ spec:
     # OCI registry hosting the chart (no chart name in the URL).
     repoURL: ghcr.io/t-clo-902-kubequest/kubequest/charts
     chart: sample-app
-    # Pinned semver — bump to match the chart/image released by CI.
-    targetRevision: 0.1.0
+    # Semver range, not a fixed pin: Argo CD resolves it against the OCI tags on
+    # each refresh and pulls the newest published chart that matches, so CI
+    # releases roll out automatically (selfHeal syncs them). Chart and image
+    # share the same semver, so this upgrades both. Capped below 1.0.0 to keep
+    # a potential breaking major out of the automatic rollout.
+    targetRevision: ">=0.2.0 <1.0.0"
     helm:
       valuesObject:
         app:


### PR DESCRIPTION
## Quoi

Remplace le pin fixe `targetRevision` par un **range semver** `">=0.2.0 <1.0.0"`.

Argo CD résout le range contre les tags OCI à chaque refresh et tire le dernier chart publié qui matche. Combiné au `automated/selfHeal` déjà actif, **les releases CI se déploient automatiquement** — plus de bump manuel à chaque version. Plafonné sous `1.0.0` pour garder un éventuel major cassant hors du rollout auto.

## Effet immédiat

Débloque aussi le déploiement courant : le range matche le chart `0.2.0` fraîchement publié (image multi-arch amd64+arm64), donc les pods passeront enfin `Running`.

Suite de #65 / #66 / #68 / #71.