### PR TITLE
fix(argocd): use cross-namespace FQDN for sample-app DB host

### DIFF
--- a/argocd/apps/sample-app/application.yaml
+++ b/argocd/apps/sample-app/application.yaml
@@ -43,6 +43,10 @@ spec:
           # no secret material is committed to Git.
           existingSecret: sample-app
         db:
+          # MySQL runs in the "mysql" namespace; the app in "sample-app". The
+          # short name "mysql" only resolves within the same namespace, so use
+          # the cross-namespace FQDN.
+          host: mysql.mysql.svc.cluster.local
           # Match the database/user the MySQL chart actually provisions
           # (helm/mysql/values.yaml: auth.database/username = "laravel").
           # The password lives in the existingSecret above (copied from


### PR DESCRIPTION
## Quoi

Le pod sample-app démarrait mais renvoyait HTTP 500 (probes KO, crash-loop). Cause : `SQLSTATE[HY000] [2002] getaddrinfo for mysql failed`. L'app tourne dans le namespace `sample-app`, MySQL dans `mysql` → le nom court `mysql` ne résout pas cross-namespace.

Override `db.host` vers le FQDN `mysql.mysql.svc.cluster.local`.

Dernier maillon du déploiement (suite #65/#66/#68/#71/#72).