### PR TITLE
feat(sample-app): run DB migrations via an initContainer

### DIFF
--- a/helm/sample-app/templates/_helpers.tpl
+++ b/helm/sample-app/templates/_helpers.tpl
@@ -18,3 +18,34 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "sample-app.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Application environment, shared by the app container and the migrate
+initContainer so both connect to the same database.
+*/}}
+{{- define "sample-app.env" -}}
+- name: APP_ENV
+  value: {{ .Values.app.env | quote }}
+- name: APP_DEBUG
+  value: {{ .Values.app.debug | quote }}
+- name: APP_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.existingSecret | default (include "sample-app.fullname" .) }}
+      key: APP_KEY
+- name: DB_CONNECTION
+  value: mysql
+- name: DB_HOST
+  value: {{ .Values.db.host | quote }}
+- name: DB_PORT
+  value: {{ .Values.db.port | quote }}
+- name: DB_DATABASE
+  value: {{ .Values.db.database | quote }}
+- name: DB_USERNAME
+  value: {{ .Values.db.username | quote }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.existingSecret | default (include "sample-app.fullname" .) }}
+      key: DB_PASSWORD
+{{- end }}

--- a/helm/sample-app/templates/deployment.yaml
+++ b/helm/sample-app/templates/deployment.yaml
@@ -17,6 +17,18 @@ spec:
       securityContext:
         runAsNonRoot: false  # Apache requires root to bind port 80
         fsGroup: 33          # www-data
+      initContainers:
+        # Apply database migrations before the app serves traffic. `migrate` is
+        # idempotent — already-applied migrations are skipped — so it is safe to
+        # run on every rollout and scale-up.
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["php", "artisan", "migrate", "--force"]
+          env:
+            {{- include "sample-app.env" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
       containers:
         - name: app
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -26,30 +38,7 @@ spec:
               containerPort: 80
               protocol: TCP
           env:
-            - name: APP_ENV
-              value: {{ .Values.app.env | quote }}
-            - name: APP_DEBUG
-              value: {{ .Values.app.debug | quote }}
-            - name: APP_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.existingSecret | default (include "sample-app.fullname" .) }}
-                  key: APP_KEY
-            - name: DB_CONNECTION
-              value: mysql
-            - name: DB_HOST
-              value: {{ .Values.db.host | quote }}
-            - name: DB_PORT
-              value: {{ .Values.db.port | quote }}
-            - name: DB_DATABASE
-              value: {{ .Values.db.database | quote }}
-            - name: DB_USERNAME
-              value: {{ .Values.db.username | quote }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.existingSecret | default (include "sample-app.fullname" .) }}
-                  key: DB_PASSWORD
+            {{- include "sample-app.env" . | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
## Quoi

Le pod renvoyait HTTP 500 car la base `laravel` était vide (`Migration table not found`). Ajoute un **initContainer `migrate`** qui exécute `php artisan migrate --force` avant le conteneur applicatif. `migrate` étant idempotent, c'est sûr à chaque rollout/scale-up.

Factorise l'environnement APP/DB partagé dans un helper `sample-app.env` (conteneur app + initContainer restent synchronisés).

## Effet

Après publication du chart (bump CI) et résolution par le range semver, les migrations seront jouées → l'app répondra 200 et les pods passeront `Running`.

Dernier maillon fonctionnel (suite #65/#66/#68/#71/#72/#73).