### PR TITLE
refactor(argocd): split sample-app values into a Git ref source

### DIFF
--- a/argocd/apps/sample-app/application.yaml
+++ b/argocd/apps/sample-app/application.yaml
@@ -3,8 +3,9 @@
 # Unlike the other workloads (which sync rendered manifests from this Git repo),
 # this Application installs the Helm chart published to GHCR as an OCI artifact
 # by .github/workflows/sample-app-build.yml. The chart and image share the same
-# semver, so a targetRevision range tracks both (see the source.targetRevision
-# note below for how new releases roll out automatically).
+# semver, so a targetRevision range tracks both (see the targetRevision note in
+# the OCI source below for how new releases roll out automatically). Values are
+# split into a second (Git ref) source; see the `sources` block.
 #
 # Secrets (APP_KEY, DB_PASSWORD) are NOT passed here — they live in a Secret
 # created out-of-band on the cluster (never committed). The chart's
@@ -26,38 +27,30 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
-  source:
+  # Multi-source: the chart comes from the OCI registry, while its
+  # deployment-time values come from this Git repo (the `ref` source). Keeping
+  # the values in a versioned file (argocd/apps/sample-app/values.yaml) makes
+  # them diffable on their own instead of living inline here.
+  sources:
     # OCI registry hosting the chart (no chart name in the URL).
-    repoURL: ghcr.io/t-clo-902-kubequest/kubequest/charts
-    chart: sample-app
-    # Semver range, not a fixed pin: Argo CD resolves it against the OCI tags on
-    # each refresh and pulls the newest published chart that matches, so CI
-    # releases roll out automatically (selfHeal syncs them). Chart and image
-    # share the same semver, so this upgrades both. Capped below 1.0.0 to keep
-    # a potential breaking major out of the automatic rollout.
-    targetRevision: ">=0.2.0 <1.0.0"
-    helm:
-      valuesObject:
-        app:
-          # Read APP_KEY / DB_PASSWORD from this pre-existing cluster Secret so
-          # no secret material is committed to Git.
-          existingSecret: sample-app
-          # Demo: set this to true (and sync) to make /up fail, so the new
-          # canary never becomes Ready and Argo Rollouts rolls it back
-          # automatically. Set back to false to recover. The app is deployed as
-          # an Argo Rollouts Rollout (canary); see helm/sample-app.
-          forceUnhealthy: false
-        db:
-          # MySQL runs in the "mysql" namespace; the app in "sample-app". The
-          # short name "mysql" only resolves within the same namespace, so use
-          # the cross-namespace FQDN.
-          host: mysql.mysql.svc.cluster.local
-          # Match the database/user the MySQL chart actually provisions
-          # (helm/mysql/values.yaml: auth.database/username = "laravel").
-          # The password lives in the existingSecret above (copied from
-          # mysql/mysql-credentials).
-          database: laravel
-          username: laravel
+    - repoURL: ghcr.io/t-clo-902-kubequest/kubequest/charts
+      chart: sample-app
+      # Semver range, not a fixed pin: Argo CD resolves it against the OCI tags
+      # on each refresh and pulls the newest published chart that matches, so CI
+      # releases roll out automatically (selfHeal syncs them). Chart and image
+      # share the same semver, so this upgrades both. Capped below 1.0.0 to keep
+      # a potential breaking major out of the automatic rollout.
+      targetRevision: ">=0.2.0 <1.0.0"
+      helm:
+        # Layered on top of the chart's baked-in defaults. $values resolves to
+        # the `ref: values` source below.
+        valueFiles:
+          - $values/argocd/apps/sample-app/values.yaml
+    # Git repo, used only as a value source (no path => nothing is deployed
+    # from it). targetRevision tracks main so values changes sync on commit.
+    - repoURL: https://github.com/T-CLO-902-KubeQuest/KubeQuest.git
+      targetRevision: main
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: sample-app

--- a/argocd/apps/sample-app/values.yaml
+++ b/argocd/apps/sample-app/values.yaml
@@ -1,0 +1,26 @@
+# Deployment-time overrides for the sample-app chart, layered on top of the
+# chart's own defaults (baked into the OCI artifact, helm/sample-app/values.yaml).
+#
+# Referenced by argocd/apps/sample-app/application.yaml as a second (ref) source
+# via `$values/argocd/apps/sample-app/values.yaml`, so this config is versioned
+# and diffable on its own instead of living inline in the Application manifest.
+app:
+  # Read APP_KEY / DB_PASSWORD from this pre-existing cluster Secret so no secret
+  # material is committed to Git.
+  existingSecret: sample-app
+  # Demo: set this to true (and sync) to make /up fail, so the new canary never
+  # becomes Ready and Argo Rollouts rolls it back automatically. Set back to
+  # false to recover. The app is deployed as an Argo Rollouts Rollout (canary);
+  # see helm/sample-app.
+  forceUnhealthy: false
+
+db:
+  # MySQL runs in the "mysql" namespace; the app in "sample-app". The short name
+  # "mysql" only resolves within the same namespace, so use the cross-namespace
+  # FQDN.
+  host: mysql.mysql.svc.cluster.local
+  # Match the database/user the MySQL chart actually provisions
+  # (helm/mysql/values.yaml: auth.database/username = "laravel"). The password
+  # lives in the existingSecret above (copied from mysql/mysql-credentials).
+  database: laravel
+  username: laravel


### PR DESCRIPTION
Converts the `sample-app` Application from a single OCI source to a **multi-source**
setup, so its deployment-time values live in a versioned, diffable file instead of
inline in the Application manifest.

## What changed
- `argocd/apps/sample-app/application.yaml`: `source:` → `sources:` (plural).
  - Source 1: the OCI chart (unchanged repoURL/chart/targetRevision), now with
    `helm.valueFiles: [$values/argocd/apps/sample-app/values.yaml]`.
  - Source 2: this Git repo with `ref: values` and **no path** (value-only source).
- New `argocd/apps/sample-app/values.yaml`: the extracted overrides
  (`app.existingSecret`, `app.forceUnhealthy`, `db.host/database/username`),
  previously inline under `helm.valuesObject`.

## Why
Keep the deployment config out of the Application manifest, versioned and reviewable
on its own.

## Validation
- Argo CD on the cluster is **v3.4.3** → multi-source `$values` is GA.
- Rendered the packaged chart `0.4.0` with the new values file vs the old inline
  `valuesObject`: **`diff` is empty (identical)**. DB host (`mysql.mysql.svc.cluster.local`),
  `existingSecret`, and `APP_FORCE_UNHEALTHY` are all preserved.

Note: `$values` path resolution happens in the Argo CD repo-server, so confirm the
app stays `Synced/Healthy` after sync (no behavioural change expected).