### PR TITLE
feat(kyverno): enforce critical security policies + harden sample-app

### DIFF
--- a/helm/sample-app/templates/rollout.yaml
+++ b/helm/sample-app/templates/rollout.yaml
@@ -31,7 +31,10 @@ spec:
         {{- include "sample-app.labels" . | nindent 8 }}
     spec:
       securityContext:
-        runAsNonRoot: false  # Apache requires root to bind port 80
+        # Apache écoute sur 8080 (port non privilégié), le pod tourne en www-data.
+        runAsNonRoot: true
+        runAsUser: 33        # www-data
+        runAsGroup: 33       # www-data
         fsGroup: 33          # www-data
       initContainers:
         # Apply database migrations before the app serves traffic. `migrate` is
@@ -43,6 +46,11 @@ spec:
           command: ["php", "artisan", "migrate", "--force"]
           env:
             {{- include "sample-app.env" . | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       containers:
@@ -51,7 +59,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           env:
             {{- include "sample-app.env" . | nindent 12 }}
@@ -74,6 +82,11 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 5
             failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       nodeSelector:

--- a/k8s/kyverno-policies/README.md
+++ b/k8s/kyverno-policies/README.md
@@ -1,0 +1,79 @@
+# Kyverno policies
+
+Validating admission policies enforced cluster-wide by the Kyverno webhook
+(deployed via `argocd/apps/kyverno-policies/`). They cover the directives'
+requirement for a validating webhook that **validates *and* controls** admission
+requests.
+
+## Enforcement modes
+
+Each `ClusterPolicy` sets `validate.failureAction`:
+
+- **`Enforce`** — the webhook **rejects** non-compliant Pods at admission.
+- **`Audit`** — the webhook only **records** violations in `PolicyReport`s
+  (`kubectl get polr -A`); the Pod is still admitted.
+
+| Policy | Mode | What it checks |
+|--------|------|----------------|
+| `disallow-privileged` | **Enforce** | `securityContext.privileged` must be false |
+| `disallow-privilege-escalation` | **Enforce** | `allowPrivilegeEscalation: false` on every container |
+| `drop-all-capabilities` | **Enforce** | `capabilities.drop: [ALL]` on every container |
+| `require-resource-limits` | **Enforce** | CPU + memory `limits` on every container |
+| `require-run-as-non-root` | **Enforce** | pod-level `runAsNonRoot: true` |
+| `disallow-latest-tag` | Audit | explicit, non-`:latest` image tag |
+| `disallow-host-namespaces` | Audit | no `hostNetwork`/`hostIPC`/`hostPID` |
+| `require-read-only-root-fs` | Audit | `readOnlyRootFilesystem: true` |
+| `require-probes` | Audit | liveness + readiness probes |
+| `require-resource-requests` | Audit | CPU + memory `requests` |
+
+### Namespace scope of the Enforce policies
+
+The 5 `Enforce` policies **exclude system/infra namespaces** (`kube-system`,
+`kyverno`, `argocd`, `argo-rollouts`, `monitoring`, `cert-manager`,
+`ingress-nginx`, `dex`, `headlamp`, `oauth2-proxy`, `local-path-storage`, …).
+Those namespaces host vendored third-party workloads we do not control and
+cannot make fully compliant; enforcing there would block them.
+
+The exclusion is **fail-closed**: any namespace *not* listed stays enforced, so
+application namespaces (`sample-app`, `mysql`) are protected by default — and so
+is any new application namespace, unless it is explicitly added to the exclude
+list.
+
+## Demo: the admission controller blocks a non-compliant Pod
+
+Try to schedule a privileged Pod in an **application** namespace — it is rejected:
+
+```console
+$ kubectl -n sample-app run pwn --image=nginx:1.27 \
+    --overrides='{"spec":{"containers":[{"name":"pwn","image":"nginx:1.27","securityContext":{"privileged":true}}]}}' \
+    --restart=Never
+Error from server: admission webhook "validate.kyverno.svc-fail" denied the request:
+
+resource Pod/sample-app/pwn was blocked due to the following policies:
+
+disallow-privileged:
+  check-privileged: 'validation error: Privileged containers are not allowed
+    (securityContext.privileged must be false).'
+```
+
+The same Pod is **admitted** in an excluded system namespace (then clean up):
+
+```console
+$ kubectl -n kube-system run probe --image=nginx:1.27 \
+    --overrides='{"spec":{"containers":[{"name":"probe","image":"nginx:1.27","securityContext":{"privileged":true}}]}}' \
+    --restart=Never
+pod/probe created
+
+$ kubectl -n kube-system delete pod probe
+```
+
+Inspect the active enforcement state:
+
+```console
+$ kubectl get clusterpolicy
+NAME                            ADMISSION   BACKGROUND   VALIDATE ACTION   READY
+disallow-privileged             true        true         Enforce           True
+require-run-as-non-root         true        true         Enforce           True
+...
+disallow-latest-tag             true        true         Audit             True
+```

--- a/k8s/kyverno-policies/disallow-privilege-escalation.yaml
+++ b/k8s/kyverno-policies/disallow-privilege-escalation.yaml
@@ -11,8 +11,29 @@ spec:
           - resources:
               kinds:
                 - Pod
+      # System/infra namespaces host vendored third-party workloads we do not
+      # control (and cannot make fully compliant); Enforce there would block
+      # them. Application namespaces stay enforced (fail-closed: any namespace
+      # not listed here is blocked).
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - argocd
+                - argo-rollouts
+                - monitoring
+                - cert-manager
+                - ingress-nginx
+                - dex
+                - headlamp
+                - oauth2-proxy
+                - local-path-storage
       validate:
-        failureAction: Audit
+        failureAction: Enforce
         message: "allowPrivilegeEscalation must be set to false on every container."
         pattern:
           spec:

--- a/k8s/kyverno-policies/disallow-privileged.yaml
+++ b/k8s/kyverno-policies/disallow-privileged.yaml
@@ -11,8 +11,29 @@ spec:
           - resources:
               kinds:
                 - Pod
+      # System/infra namespaces host vendored third-party workloads we do not
+      # control (and cannot make fully compliant); Enforce there would block
+      # them. Application namespaces stay enforced (fail-closed: any namespace
+      # not listed here is blocked).
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - argocd
+                - argo-rollouts
+                - monitoring
+                - cert-manager
+                - ingress-nginx
+                - dex
+                - headlamp
+                - oauth2-proxy
+                - local-path-storage
       validate:
-        failureAction: Audit
+        failureAction: Enforce
         message: "Privileged containers are not allowed (securityContext.privileged must be false)."
         pattern:
           spec:

--- a/k8s/kyverno-policies/drop-all-capabilities.yaml
+++ b/k8s/kyverno-policies/drop-all-capabilities.yaml
@@ -11,8 +11,29 @@ spec:
           - resources:
               kinds:
                 - Pod
+      # System/infra namespaces host vendored third-party workloads we do not
+      # control (and cannot make fully compliant); Enforce there would block
+      # them. Application namespaces stay enforced (fail-closed: any namespace
+      # not listed here is blocked).
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - argocd
+                - argo-rollouts
+                - monitoring
+                - cert-manager
+                - ingress-nginx
+                - dex
+                - headlamp
+                - oauth2-proxy
+                - local-path-storage
       validate:
-        failureAction: Audit
+        failureAction: Enforce
         message: "Every container must drop ALL capabilities (securityContext.capabilities.drop: [ALL])."
         pattern:
           spec:

--- a/k8s/kyverno-policies/require-resource-limits.yaml
+++ b/k8s/kyverno-policies/require-resource-limits.yaml
@@ -10,8 +10,29 @@ spec:
           - resources:
               kinds:
                 - Pod
+      # System/infra namespaces host vendored third-party workloads we do not
+      # control (and cannot make fully compliant); Enforce there would block
+      # them. Application namespaces stay enforced (fail-closed: any namespace
+      # not listed here is blocked).
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - argocd
+                - argo-rollouts
+                - monitoring
+                - cert-manager
+                - ingress-nginx
+                - dex
+                - headlamp
+                - oauth2-proxy
+                - local-path-storage
       validate:
-        failureAction: Audit
+        failureAction: Enforce
         message: "Resource limits are required for CPU and memory."
         pattern:
           spec:

--- a/k8s/kyverno-policies/require-run-as-non-root.yaml
+++ b/k8s/kyverno-policies/require-run-as-non-root.yaml
@@ -11,8 +11,29 @@ spec:
           - resources:
               kinds:
                 - Pod
+      # System/infra namespaces host vendored third-party workloads we do not
+      # control (and cannot make fully compliant); Enforce there would block
+      # them. Application namespaces stay enforced (fail-closed: any namespace
+      # not listed here is blocked).
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - argocd
+                - argo-rollouts
+                - monitoring
+                - cert-manager
+                - ingress-nginx
+                - dex
+                - headlamp
+                - oauth2-proxy
+                - local-path-storage
       validate:
-        failureAction: Audit
+        failureAction: Enforce
         message: "Pods must set spec.securityContext.runAsNonRoot to true."
         pattern:
           spec:

--- a/sample-app/Dockerfile
+++ b/sample-app/Dockerfile
@@ -32,5 +32,14 @@ RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf
 # Activez le module Apache Rewrite
 RUN a2enmod rewrite
 
-# Exposez le port 80
-EXPOSE 80
+# Apache écoute sur un port non privilégié (8080) afin de tourner en non-root
+# et satisfaire les policies Kyverno en mode Enforce (runAsNonRoot, drop ALL caps).
+RUN sed -ri -e 's!^Listen 80$!Listen 8080!' /etc/apache2/ports.conf \
+    && sed -ri -e 's!<VirtualHost \*:80>!<VirtualHost *:8080>!' /etc/apache2/sites-available/*.conf \
+    && chown -R www-data:www-data /var/run/apache2 /var/log/apache2 /var/lib/apache2
+
+# Tournez en tant qu'utilisateur non privilégié www-data.
+USER www-data
+
+# Exposez le port non privilégié
+EXPOSE 8080


### PR DESCRIPTION
Closes #88.

## Quoi

Passe les 5 policies Kyverno critiques de `Audit` à `Enforce` pour que le validating webhook **bloque** les Pods non conformes à l'admission (et non plus seulement les journalise) :

- `disallow-privileged`
- `disallow-privilege-escalation`
- `drop-all-capabilities`
- `require-resource-limits`
- `require-run-as-non-root`

Les 5 autres policies restent en `Audit`.

## Scope des policies Enforce

Les namespaces système/infra (qui hébergent des workloads tiers vendorisés non maîtrisables : `kube-system`, `kyverno`, `argocd`, `argo-rollouts`, `monitoring`, `cert-manager`, `ingress-nginx`, `dex`, `headlamp`, `oauth2-proxy`, `local-path-storage`) sont **exclus** via un bloc `exclude:`. L'exclusion est **fail-closed** : tout namespace non listé reste bloquant, donc les namespaces applicatifs (`sample-app`, `mysql`) sont protégés par défaut.

## sample-app rendu conforme

Apache bindait le port privilégié 80 en root (`runAsNonRoot: false`), ce qui échouerait sous Enforce. Désormais :
- Apache écoute sur **8080** (port non privilégié), conteneur en **www-data** (uid 33).
- Pod `securityContext` : `runAsNonRoot: true`.
- Conteneurs `app` + `migrate` : `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`.
- Le Service cible le port nommé `http` → suit automatiquement 8080, **aucun changement Service/Ingress**.

`mysql` était déjà conforme.

## Ordre de merge ⚠️

Cette PR contient **2 commits séquencés** :
1. `feat(sample-app): run rootless on port 8080…` — la CI rebuild/republie l'image+chart conformes.
2. `feat(kyverno): enforce critical security policies…` — active Enforce.

Idéalement, laisser la CI publier la nouvelle image sample-app conforme **avant** qu'ArgoCD ne synchronise les policies Enforce, sinon un `selfHeal` pourrait rejeter le pod sample-app actuel (non conforme). Si merge en une fois, surveiller que le rollout sample-app reprend bien avec la nouvelle image.

## Démo / vérification

Voir `k8s/kyverno-policies/README.md`. En résumé :
- Pod `privileged` dans `sample-app` → **rejeté** par l'admission webhook.
- Même Pod dans `kube-system` → **admis** (namespace exclu).
- `kubectl get clusterpolicy` → 5 en `Enforce`, 5 en `Audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)