### PR TITLE
fix: libssh2

### DIFF
--- a/.github/workflows/sample-app-broken.yml
+++ b/.github/workflows/sample-app-broken.yml
@@ -44,7 +44,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push broken image (tag: broken)
+      - name: "Build & push broken image (tag: broken)"
         uses: docker/build-push-action@v6
         with:
           context: ./sample-app

--- a/sample-app/Dockerfile
+++ b/sample-app/Dockerfile
@@ -6,7 +6,11 @@ FROM php:8.3-apache
 RUN docker-php-ext-install pdo_mysql
 
 # Patche les paquets OS de l'image de base, puis installe les dépendances.
-RUN apt-get update \
+# APT_REFRESH : changer cette date invalide le cache de cette seule couche pour
+# forcer apt-get upgrade à récupérer les derniers correctifs OS (ex. libssh2).
+ARG APT_REFRESH=2026-06-27
+RUN echo "apt refresh: ${APT_REFRESH}" \
+    && apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends git unzip p7zip-full \
     && apt-get clean \


### PR DESCRIPTION
for apt-get upgrade instead of using cache