### PR TITLE
feat(vault): deploy HashiCorp Vault standalone with Integrated Storage

### DIFF
--- a/adr/0005-vault-secrets-management.md
+++ b/adr/0005-vault-secrets-management.md
@@ -1,0 +1,74 @@
+# 0005 - Gestion des secrets avec HashiCorp Vault (standalone + Raft)
+
+- Statut : Accepted
+- Date : 2026-07-02
+- Décideurs : équipe KubeQuest
+- PR : à compléter à l'ouverture
+
+## Contexte
+
+La gestion des secrets Kubernetes du cluster est aujourd'hui 100% manuelle et
+hors-Git : `mysql-credentials` (`k8s/mysql/README.md`),
+`dex-github`/`dex-clients` (`k8s/dex/README.md`), `grafana-admin`/
+`grafana-oidc` (`k8s/monitoring/README.md`) et `oauth2-proxy`
+(`k8s/oauth2-proxy/README.md`) sont tous créés à la main via
+`kubectl create secret generic ... --from-literal=$(openssl rand -base64 24)`.
+Cette dette technique est déjà documentée à plusieurs endroits — le README
+MySQL évoque même explicitement Sealed Secrets comme piste jamais
+implémentée.
+
+## Décision
+
+Déployer **HashiCorp Vault** en mode **standalone avec Integrated Storage
+(Raft)** : un seul pod, storage backend Raft plutôt que le backend `file`
+historique, sans mode HA multi-replica du chart. Activer le **Vault Agent
+Injector** packagé nativement dans le chart officiel
+(`injector.enabled`, défaut du chart). Configurer l'auth method Kubernetes
+avec une policy/role minimale de démonstration (`demo-policy`/`demo-role`,
+KV `secret/demo/example`) pour prouver que l'ensemble fonctionne, **sans**
+migrer les secrets existants dans ce lot — ce sera un travail futur séparé.
+
+Exposer l'UI via Ingress + cert-manager (`letsencrypt-prod`) + **oauth2-proxy**
+en forward-auth (`k8s/oauth2-proxy/README.md`), car l'UI Vault OSS n'a pas
+d'OIDC natif simple à activer, contrairement à Grafana.
+
+## Alternatives envisagées
+
+- **Vault HA (3+ replicas Raft)** : rejeté. Le cluster ne dispose que de 2
+  workers à 4 GB RAM chacun, déjà partagés entre MySQL, le stack monitoring,
+  Argo CD et le reste — pas de marge confortable pour un quorum Raft
+  multi-nœud en plus.
+- **Auto-unseal AWS KMS dès ce lot** : rejeté pour l'instant. Nécessite du
+  wiring IAM (rôle IAM pour le pod, policy KMS) absent de l'infra Terraform
+  actuelle. Reporté en dette technique explicite (voir Conséquences).
+- **Sealed Secrets** (déjà évoqué comme piste dans `k8s/mysql/README.md`) à la
+  place de Vault : rejeté pour ce lot — l'énoncé demande spécifiquement
+  HashiCorp Vault, qui apporte en plus l'injection dynamique via l'Injector
+  (pas seulement du chiffrement statique de manifestes Secret).
+- **External Secrets Operator + Vault** au lieu de l'Injector natif : non
+  retenu pour ce lot. L'Injector est packagé nativement dans le chart
+  officiel (`injector.enabled`), plus simple à poser en fondation ; ESO
+  pourra être réévalué lors de la migration effective des secrets existants.
+
+## Conséquences
+
+### Positives
+
+- Fondation posée pour sortir de la gestion manuelle des secrets : Injector
+  fonctionnel, auth Kubernetes activée, démontré avec un exemple KV de bout
+  en bout.
+- Reste dans le pattern "vendored manifest" du repo : aucun `helm install`
+  ni release Helm sur le cluster, tout passe par un manifeste rendu et
+  committé, synchronisé par Argo CD.
+
+### Négatives / points d'attention
+
+- **Pas d'auto-unseal** : chaque redémarrage du pod (OOMKill, reschedule,
+  reboot du nœud) re-scelle Vault et exige une intervention manuelle avec 3
+  des 5 clés — tant que cette intervention n'a pas eu lieu, Vault et tout
+  consommateur futur de l'Injector sont indisponibles.
+- **Pas de HA** : un seul pod, donc un point de défaillance unique assumé.
+- **Secrets existants non migrés** : Vault coexiste avec les Secrets créés à
+  la main jusqu'à un futur ticket de migration.
+- **Stockage `local-path`** : comme MySQL, le PVC est lié au disque local
+  d'un seul nœud worker — pas de résilience en cas de perte du nœud.

--- a/adr/README.md
+++ b/adr/README.md
@@ -20,3 +20,4 @@ contexte et ses conséquences.
 | [0002](0002-mysql-network-policy-and-backup-hardening.md) | Durcissement de la NetworkPolicy et des backups MySQL | Accepted |
 | [0003](0003-native-multiarch-image-build.md) | Build multi-arch natif de l'image sample-app | Accepted |
 | [0004](0004-argo-rollouts-canary-deployment.md) | Déploiement canary et rollback automatique avec Argo Rollouts | Accepted |
+| [0005](0005-vault-secrets-management.md) | Gestion des secrets avec HashiCorp Vault (standalone + Raft) | Accepted |

--- a/argocd/apps/vault/application.yaml
+++ b/argocd/apps/vault/application.yaml
@@ -1,0 +1,32 @@
+# HashiCorp Vault (standalone + Integrated Storage/Raft) with the Vault Agent
+# Injector enabled, synced by the root app-of-apps.
+#
+# vault.yaml = server + injector rendered from the official chart; ingress.yaml
+# = UI exposure at vault.kubequest.epitech.beer (issue: Vault secrets mgmt).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/T-CLO-902-KubeQuest/KubeQuest.git
+    targetRevision: main
+    path: k8s/vault
+    directory:
+      include: "{vault.yaml,ingress.yaml}"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vault
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/helm/vault/values.yaml
+++ b/helm/vault/values.yaml
@@ -1,0 +1,60 @@
+# Vault values used to render k8s/vault/vault.yaml.
+# Regenerate the manifest with:
+#   helm repo add hashicorp https://helm.releases.hashicorp.com
+#   helm repo update hashicorp
+#   helm template vault hashicorp/vault \
+#     --version 0.32.0 \
+#     --namespace vault \
+#     --values helm/vault/values.yaml \
+#     > k8s/vault/vault.yaml
+#
+# Pinned chart version: 0.32.0 (app version 1.21.2).
+#
+# Only values that DIFFER from the chart defaults live here; Helm deep-merges,
+# so untouched keys keep the chart's recommended values.
+
+# --- Mode: standalone with Integrated Storage (Raft) ---
+# The chart's "ha" mode deploys a multi-replica StatefulSet with Raft
+# clustering between pods (server.ha.raft.enabled) — we do NOT want that on
+# this 2-worker/4GB cluster. Instead we keep server.ha.enabled: false (the
+# chart default) and use "standalone" mode, but override its config to swap
+# the default `storage "file"` backend for `storage "raft"`. This is a single
+# pod using Integrated Storage: no external Consul, no multi-node quorum, but
+# still the modern Raft storage engine instead of the legacy file backend.
+server:
+  standalone:
+    enabled: true
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "raft" {
+        path = "/vault/data"
+      }
+
+  dataStorage:
+    enabled: true
+    size: 2Gi
+    storageClass: local-path
+    accessMode: ReadWriteOnce
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+injector:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi

--- a/k8s/vault/README.md
+++ b/k8s/vault/README.md
@@ -1,0 +1,150 @@
+# HashiCorp Vault
+
+## Overview
+Vault is the cluster's future single source of truth for secrets. Today,
+every credential is created by hand and kept out of Git: `mysql-credentials`
+(`k8s/mysql/README.md`), `dex-github`/`dex-clients` (`k8s/dex/README.md`),
+`grafana-admin`/`grafana-oidc` (`k8s/monitoring/README.md`) and `oauth2-proxy`
+(`k8s/oauth2-proxy/README.md`) — each README documents this as technical debt.
+
+This ticket deploys Vault itself, with the **Vault Agent Injector** enabled
+and the Kubernetes auth method configured with a minimal demo policy/role
+proving the mechanism works. **Migrating the existing secrets above is out of
+scope** — a follow-up piece of work once this foundation is in place.
+
+## Design: vendored manifest
+Like Cilium, Argo CD, cert-manager, Kyverno, MySQL and oauth2-proxy, Vault is
+installed from a manifest checked into the repo (`k8s/vault/vault.yaml`),
+rendered with `helm template` — never `helm install` (no Helm release state on
+the cluster). Every change is a reviewable diff alongside its source values
+(`helm/vault/values.yaml`).
+
+### Regenerating the manifest
+```sh
+helm repo add hashicorp https://helm.releases.hashicorp.com
+helm repo update hashicorp
+helm template vault hashicorp/vault \
+  --version 0.32.0 \
+  --namespace vault \
+  --values helm/vault/values.yaml \
+  > k8s/vault/vault.yaml
+```
+Pinned chart version: **0.32.0** (app version Vault **1.21.2**). Bump it here
+and in the command above, then commit the regenerated manifest with the
+values change.
+
+## Mode: standalone with Integrated Storage (Raft)
+The chart's `server.ha.*` block deploys a multi-replica StatefulSet with Raft
+clustering **between pods** — deliberately not used here: this cluster has
+only 2 workers at 4 GB RAM each, no comfortable room for a multi-node Raft
+quorum alongside MySQL, monitoring and everything else.
+
+Instead, `server.ha.enabled` stays at its chart default (`false`) and
+`server.standalone.enabled: true` is used, but with its `config` overridden to
+swap the default `storage "file"` backend for `storage "raft"`
+(`helm/vault/values.yaml`). This is a **single pod** using the modern
+Integrated Storage engine — no external Consul, no multi-node quorum, but no
+HA either: Vault is a single point of failure by design in this deployment.
+
+Persistent storage: a 2Gi PVC on the **`local-path`** StorageClass (same as
+MySQL), `server.dataStorage`.
+
+## Initialization and unseal (manual, post-deployment)
+Vault standalone starts **sealed**. Unlike the managed-cloud offerings, this
+deployment has no auto-unseal configured (see "Production evolution" below),
+so this is a one-time, then repeat-after-every-restart, manual procedure:
+
+```sh
+kubectl -n vault exec -it vault-0 -- vault operator init \
+  -key-shares=5 -key-threshold=3
+# Store the 5 unseal keys and the root token somewhere safe, OUTSIDE Git.
+# Never commit real key/token values, even as "examples".
+
+kubectl -n vault exec -it vault-0 -- vault operator unseal <key1>
+kubectl -n vault exec -it vault-0 -- vault operator unseal <key2>
+kubectl -n vault exec -it vault-0 -- vault operator unseal <key3>
+```
+
+Any of the 5 keys works as long as 3 distinct ones are supplied. Check status
+at any time with `kubectl -n vault exec -it vault-0 -- vault status`.
+
+> The pod's readiness probe expects Vault to be unsealed, so `vault-0` will
+> show `0/1 Ready` (and Argo CD will report the `vault` Application as
+> `Progressing`/`Degraded`) between deployment and the first unseal. This is
+> expected — not a sync failure.
+
+## Kubernetes auth method (Injector foundation, demo only)
+Enable the auth method Vault needs to validate Kubernetes ServiceAccount
+tokens, then a minimal policy/role to prove the Injector path works end to
+end:
+
+```sh
+kubectl exec -it vault-0 -n vault -- vault login <root-token>
+kubectl exec -it vault-0 -n vault -- vault auth enable kubernetes
+kubectl exec -it vault-0 -n vault -- vault write auth/kubernetes/config \
+  kubernetes_host="https://kubernetes.default.svc:443"
+
+kubectl exec -it vault-0 -n vault -- vault secrets enable -path=secret kv-v2
+kubectl exec -it vault-0 -n vault -- vault kv put secret/demo/example \
+  username=demo password=demo123
+
+kubectl exec -it vault-0 -n vault -- vault policy write demo-policy - <<'EOF'
+path "secret/data/demo/*" {
+  capabilities = ["read"]
+}
+EOF
+
+kubectl exec -it vault-0 -n vault -- vault write auth/kubernetes/role/demo-role \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=default \
+  policies=demo-policy \
+  ttl=1h
+```
+
+This `demo-role`/`demo-policy` pair is purely illustrative (bound to the
+`default` ServiceAccount/namespace) — it exists to prove the Injector and
+Kubernetes auth method are wired correctly, not to protect anything real.
+
+**Next steps (future ticket):** migrate `mysql-credentials`, `dex-github`,
+`dex-clients`, `grafana-admin`, `grafana-oidc` and `oauth2-proxy` into KV
+paths with dedicated Kubernetes roles (one per consuming app), and add
+`vault.hashicorp.com/agent-inject: "true"` annotations to the relevant
+Deployments/StatefulSets.
+
+## Exposure & TLS
+The UI is reachable at `vault.kubequest.epitech.beer` (`k8s/vault/ingress.yaml`).
+Vault's listener has `tls_disable = 1`, so the Service serves plain HTTP;
+TLS is terminated at the Ingress by cert-manager on the `letsencrypt-prod`
+issuer (HTTP-01). The HTTP-01 self-check needs a CoreDNS `hosts` entry for
+`vault.kubequest.epitech.beer` — see `k8s/cert-manager/README.md`. A matching
+DNS A record must also exist at the DNS provider (`epitech.beer`) — both are
+manual, out-of-Git steps.
+
+## SSO (oauth2-proxy)
+Vault's OSS UI has no simple native OIDC login, so — unlike Grafana, which
+speaks OIDC to Dex directly — the Vault Ingress delegates authentication to
+**oauth2-proxy**'s nginx `auth_request` forward-auth, using the annotations
+documented in `k8s/oauth2-proxy/README.md` ("Protecting a future tool"). This
+is the first Ingress in the cluster to actually consume that mechanism.
+Logging into the UI via SSO only proves GitHub org membership — it does not
+unseal Vault or grant any Vault policy; the two layers are independent.
+
+## Deployment
+Managed by GitOps: the `Application` at `argocd/apps/vault/application.yaml`
+(sync-wave `0`) is picked up by the root app-of-apps and synced automatically.
+No manual `kubectl apply` for the manifests — but init/unseal and the
+Kubernetes auth method setup above remain manual, out-of-Git steps.
+
+## Production evolution
+- **No auto-unseal**: every pod restart (OOMKill, reschedule, node reboot)
+  re-seals Vault and requires a manual unseal with 3 of the 5 keys. The
+  robust evolution is `seal "awskms"` in the server config, which needs IAM
+  wiring (a role for the pod, a KMS key policy) not yet present in the
+  Terraform infra — same gap already noted for the AWS EBS CSI driver in
+  `k8s/mysql/README.md`.
+- **No HA**: a single pod is a single point of failure. Multi-replica Raft
+  HA is deliberately deferred until the cluster has more headroom.
+- **Secrets not yet migrated**: Vault currently coexists with the hand-created
+  Secrets it is meant to replace.
+- **Storage tied to one node**: like MySQL, the `local-path` PVC lives on the
+  node's local disk.

--- a/k8s/vault/ingress.yaml
+++ b/k8s/vault/ingress.yaml
@@ -1,0 +1,37 @@
+# Ingress exposing the Vault UI at vault.kubequest.epitech.beer.
+#
+# Vault has no simple native OIDC login for its UI, so unlike Grafana it
+# delegates authentication to oauth2-proxy's nginx auth_request (same pattern
+# documented in k8s/oauth2-proxy/README.md, "Protecting a future tool") — this
+# is the first Ingress in the cluster to actually consume it.
+#
+# Vault's listener has tls_disable = 1 (see helm/vault/values.yaml), so the
+# Service serves plain HTTP — no backend-protocol annotation needed, HTTP is
+# ingress-nginx's default. TLS is issued by the letsencrypt-prod ClusterIssuer
+# (HTTP-01), like the rest of the cluster.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vault
+  namespace: vault
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/auth-url: "https://auth.kubequest.epitech.beer/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.kubequest.epitech.beer/oauth2/start?rd=$escaped_request_uri"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - vault.kubequest.epitech.beer
+      secretName: vault-tls
+  rules:
+    - host: vault.kubequest.epitech.beer
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: vault
+                port:
+                  number: 8200

--- a/k8s/vault/vault.yaml
+++ b/k8s/vault/vault.yaml
@@ -1,0 +1,587 @@
+---
+# Source: vault/templates/injector-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-agent-injector
+  namespace: vault
+  labels:
+    app.kubernetes.io/name: vault-agent-injector
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: vault/templates/server-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault
+  namespace: vault
+  labels:
+    helm.sh/chart: vault-0.32.0
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: vault/templates/server-config-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-config
+  namespace: vault
+  labels:
+    helm.sh/chart: vault-0.32.0
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+data:
+  extraconfig-from-values.hcl: |-
+    ui = true
+    
+    listener "tcp" {
+      tls_disable = 1
+      address = "[::]:8200"
+      cluster_address = "[::]:8201"
+    }
+    storage "raft" {
+      path = "/vault/data"
+    }
+    
+    disable_mlock = true
+---
+# Source: vault/templates/injector-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vault-agent-injector-clusterrole
+  labels:
+    app.kubernetes.io/name: vault-agent-injector
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "patch"
+---
+# Source: vault/templates/injector-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-agent-injector-binding
+  labels:
+    app.kubernetes.io/name: vault-agent-injector
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vault-agent-injector-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: vault-agent-injector
+  namespace: vault
+---
+# Source: vault/templates/server-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-server-binding
+  labels:
+    helm.sh/chart: vault-0.32.0
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: vault
+  namespace: vault
+---
+# Source: vault/templates/injector-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault-agent-injector-svc
+  namespace: vault
+  labels:
+    app.kubernetes.io/name: vault-agent-injector
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+  
+spec:
+  ports:
+  - name: https
+    port: 443
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: vault-agent-injector
+    app.kubernetes.io/instance: vault
+    component: webhook
+---
+# Source: vault/templates/server-headless-service.yaml
+# Service for Vault cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault-internal
+  namespace: vault
+  labels:
+    helm.sh/chart: vault-0.32.0
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+    vault-internal: "true"
+  annotations:
+
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: "http"
+      port: 8200
+      targetPort: 8200
+    - name: https-internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    component: server
+---
+# Source: vault/templates/server-service.yaml
+# Service for Vault cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  namespace: vault
+  labels:
+    helm.sh/chart: vault-0.32.0
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+
+spec:
+  # We want the servers to become available even if they're not ready
+  # since this DNS is also used for join operations.
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 8200
+      targetPort: 8200
+    - name: https-internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    component: server
+---
+# Source: vault/templates/injector-deployment.yaml
+# Deployment for the injector
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault-agent-injector
+  namespace: vault
+  labels:
+    app.kubernetes.io/name: vault-agent-injector
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+    component: webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vault-agent-injector
+      app.kubernetes.io/instance: vault
+      component: webhook
+  
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vault-agent-injector
+        app.kubernetes.io/instance: vault
+        component: webhook
+    spec:
+      
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: vault-agent-injector
+                  app.kubernetes.io/instance: "vault"
+                  component: webhook
+              topologyKey: kubernetes.io/hostname
+  
+      
+      
+      
+      serviceAccountName: "vault-agent-injector"
+      
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 100
+        fsGroup: 1000
+      hostNetwork: false
+      containers:
+        - name: sidecar-injector
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+  
+          image: "hashicorp/vault-k8s:1.7.2"
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: AGENT_INJECT_LISTEN
+              value: :8080
+            - name: AGENT_INJECT_LOG_LEVEL
+              value: info
+            - name: AGENT_INJECT_VAULT_ADDR
+              value: http://vault.vault.svc:8200
+            - name: AGENT_INJECT_VAULT_AUTH_PATH
+              value: auth/kubernetes
+            - name: AGENT_INJECT_VAULT_IMAGE
+              value: "hashicorp/vault:1.21.2"
+            - name: AGENT_INJECT_TLS_AUTO
+              value: vault-agent-injector-cfg
+            - name: AGENT_INJECT_TLS_AUTO_HOSTS
+              value: vault-agent-injector-svc,vault-agent-injector-svc.vault,vault-agent-injector-svc.vault.svc
+            - name: AGENT_INJECT_LOG_FORMAT
+              value: standard
+            - name: AGENT_INJECT_REVOKE_ON_SHUTDOWN
+              value: "false"
+            - name: AGENT_INJECT_CPU_REQUEST
+              value: "250m"
+            - name: AGENT_INJECT_CPU_LIMIT
+              value: "500m"
+            - name: AGENT_INJECT_MEM_REQUEST
+              value: "64Mi"
+            - name: AGENT_INJECT_MEM_LIMIT
+              value: "128Mi"
+            - name: AGENT_INJECT_DEFAULT_TEMPLATE
+              value: "map"
+            - name: AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE
+              value: "true"
+            
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          args:
+            - agent-inject
+            - 2>&1
+          livenessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTPS
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTPS
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTPS
+            failureThreshold: 12
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+---
+# Source: vault/templates/server-statefulset.yaml
+# StatefulSet to run the actual vault server cluster.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vault
+  namespace: vault
+  labels:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+spec:
+  serviceName: vault-internal
+  podManagementPolicy: Parallel
+  replicas: 1
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vault
+      app.kubernetes.io/instance: vault
+      component: server
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: vault-0.32.0
+        app.kubernetes.io/name: vault
+        app.kubernetes.io/instance: vault
+        component: server
+      annotations:
+    spec:
+      
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: vault
+                  app.kubernetes.io/instance: "vault"
+                  component: server
+              topologyKey: kubernetes.io/hostname
+  
+      
+      
+      
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: vault
+      
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 100
+        fsGroup: 1000
+      hostNetwork: false
+      volumes:
+        
+        - name: config
+          configMap:
+            name: vault-config
+  
+        - name: home
+          emptyDir: {}
+      containers:
+        - name: vault
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+  
+          image: hashicorp/vault:1.21.2
+          imagePullPolicy: IfNotPresent
+          command:
+          - "/bin/sh"
+          - "-ec"
+          args: 
+          - |
+            cp /vault/config/extraconfig-from-values.hcl /tmp/storageconfig.hcl;
+            [ -n "${HOST_IP}" ] && sed -Ei "s|HOST_IP|${HOST_IP?}|g" /tmp/storageconfig.hcl;
+            [ -n "${POD_IP}" ] && sed -Ei "s|POD_IP|${POD_IP?}|g" /tmp/storageconfig.hcl;
+            [ -n "${HOSTNAME}" ] && sed -Ei "s|HOSTNAME|${HOSTNAME?}|g" /tmp/storageconfig.hcl;
+            [ -n "${API_ADDR}" ] && sed -Ei "s|API_ADDR|${API_ADDR?}|g" /tmp/storageconfig.hcl;
+            [ -n "${TRANSIT_ADDR}" ] && sed -Ei "s|TRANSIT_ADDR|${TRANSIT_ADDR?}|g" /tmp/storageconfig.hcl;
+            [ -n "${RAFT_ADDR}" ] && sed -Ei "s|RAFT_ADDR|${RAFT_ADDR?}|g" /tmp/storageconfig.hcl;
+            /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl 
+   
+          securityContext:
+            allowPrivilegeEscalation: false
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VAULT_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VAULT_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: VAULT_ADDR
+              value: "http://127.0.0.1:8200"
+            - name: VAULT_API_ADDR
+              value: "http://$(POD_IP):8200"
+            - name: SKIP_CHOWN
+              value: "true"
+            - name: SKIP_SETCAP
+              value: "true"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VAULT_CLUSTER_ADDR
+              value: "https://$(HOSTNAME).vault-internal:8201"
+            - name: HOME
+              value: "/home/vault"
+            
+            
+            
+          volumeMounts:
+          
+  
+    
+            - name: data
+              mountPath: /vault/data
+    
+  
+  
+            - name: config
+              mountPath: /vault/config
+  
+            - name: home
+              mountPath: /home/vault
+          ports:
+            - containerPort: 8200
+              name: http
+            - containerPort: 8201
+              name: https-internal
+            - containerPort: 8202
+              name: http-rep
+          readinessProbe:
+            # Check status; unsealed vault servers return 0
+            # The exit code reflects the seal status:
+            #   0 - unsealed
+            #   1 - error
+            #   2 - sealed
+            exec:
+              command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          lifecycle:
+            # Vault container doesn't receive SIGTERM from Kubernetes
+            # and after the grace period ends, Kube sends SIGKILL.  This
+            # causes issues with graceful shutdowns such as deregistering itself
+            # from Consul (zombie services).
+            preStop:
+              exec:
+                command:
+                - "/bin/sh"
+                - "-c"
+                # Adding a sleep here to give the pod eviction a
+                # chance to propagate, so requests will not be made
+                # to this pod while it's terminating
+                - "sleep 5 && kill -SIGTERM $(pidof vault)"
+      
+  
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      
+      
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+        storageClassName: local-path
+---
+# Source: vault/templates/injector-mutating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: vault-agent-injector-cfg
+  labels:
+    app.kubernetes.io/name: vault-agent-injector
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: vault.hashicorp.com
+    failurePolicy: Ignore
+    matchPolicy: Exact
+    sideEffects: None
+    timeoutSeconds: 30
+    admissionReviewVersions: ["v1", "v1beta1"]
+    clientConfig:
+      service:
+        name: vault-agent-injector-svc
+        namespace: vault
+        path: "/mutate"
+      caBundle: ""
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+        scope: "Namespaced"
+    objectSelector:
+      matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+        - vault-agent-injector
+---
+# Source: vault/templates/tests/server-test.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vault-server-test
+  namespace: vault
+  annotations:
+    "helm.sh/hook": test
+spec:
+  
+  containers:
+    - name: vault-server-test
+      image: hashicorp/vault:1.21.2
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: VAULT_ADDR
+          value: http://vault.vault.svc:8200
+        
+      command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Checking for sealed info in 'vault status' output"
+          ATTEMPTS=10
+          n=0
+          until [ "$n" -ge $ATTEMPTS ]
+          do
+            echo "Attempt" $n...
+            vault status -format yaml | grep -E '^sealed: (true|false)' && break
+            n=$((n+1))
+            sleep 5
+          done
+          if [ $n -ge $ATTEMPTS ]; then
+            echo "timed out looking for sealed info in 'vault status' output"
+            exit 1
+          fi
+
+          exit 0
+  restartPolicy: Never


### PR DESCRIPTION
## Summary
- Deploy HashiCorp Vault (chart 0.32.0) as a vendored manifest, standalone mode with Integrated Storage (Raft) instead of the legacy file backend — no HA, sized for the 2-worker/4GB cluster.
- Enable the Vault Agent Injector and configure the Kubernetes auth method with a minimal demo policy/role proving the mechanism works end to end. Existing manual secrets (mysql, dex, grafana, oauth2-proxy) are **not** migrated in this change.
- Expose the UI at `vault.kubequest.epitech.beer` via Ingress, cert-manager (`letsencrypt-prod`), and oauth2-proxy forward-auth (first real consumer of that mechanism in the cluster).
- See `adr/0005-vault-secrets-management.md` for the full rationale and alternatives considered (HA, auto-unseal, Sealed Secrets, ESO).

## Test plan
- [ ] `argocd app get vault` — Synced (Healthy may lag until Vault is unsealed, expected)
- [ ] `kubectl get pods -n vault` — `vault-0` and injector pods present
- [ ] `kubectl -n vault exec -it vault-0 -- vault operator init -key-shares=5 -key-threshold=3`, then unseal with 3 keys (see `k8s/vault/README.md`)
- [ ] `kubectl -n vault port-forward svc/vault 8200:8200` and confirm UI loads before relying on the Ingress
- [ ] Add CoreDNS `hosts` entry + DNS A record for `vault.kubequest.epitech.beer` (see below)
- [ ] `kubectl get certificate -n vault` — `vault-tls` reaches `READY: True`
- [ ] Enable Kubernetes auth method + demo role/policy, verify `vault kv get secret/demo/example` via the role login
- [ ] `curl -I https://vault.kubequest.epitech.beer` redirects to Dex/GitHub login (oauth2-proxy)