### PR TITLE
fix(vault): drop all capabilities to satisfy kyverno policies

### DIFF
--- a/helm/vault/values.yaml
+++ b/helm/vault/values.yaml
@@ -24,8 +24,14 @@
 server:
   standalone:
     enabled: true
+    # disable_mlock is doubly required here: Vault >= 1.20 refuses to start
+    # with Integrated Storage unless it is set explicitly, and the container
+    # drops ALL capabilities (kyverno policy) so the mlock syscall would fail
+    # anyway (no IPC_LOCK). HashiCorp recommends disabling mlock with Raft:
+    # data already touches disk, so mlock adds no meaningful protection.
     config: |
       ui = true
+      disable_mlock = true
 
       listener "tcp" {
         tls_disable = 1
@@ -35,6 +41,18 @@ server:
       storage "raft" {
         path = "/vault/data"
       }
+
+  # The kyverno ClusterPolicies enforce drop-all-capabilities in app
+  # namespaces (vault is not in the infra exclusion list, and complying is
+  # better than excluding). Setting .container REPLACES the chart's default
+  # container securityContext, so allowPrivilegeEscalation must be restated.
+  statefulSet:
+    securityContext:
+      container:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
 
   dataStorage:
     enabled: true

--- a/k8s/vault/README.md
+++ b/k8s/vault/README.md
@@ -49,6 +49,16 @@ HA either: Vault is a single point of failure by design in this deployment.
 Persistent storage: a 2Gi PVC on the **`local-path`** StorageClass (same as
 MySQL), `server.dataStorage`.
 
+### Kyverno compliance
+The `vault` namespace is **not** in the Kyverno infra exclusion list
+(`helm/kyverno/values.yaml`), so the enforced ClusterPolicies apply. The
+server container therefore drops ALL capabilities
+(`server.statefulSet.securityContext.container` in `helm/vault/values.yaml`),
+which also means no `IPC_LOCK`: `disable_mlock = true` is set in the server
+config — required anyway by Vault >= 1.20 with Integrated Storage, and
+HashiCorp's recommendation for Raft (data already touches disk, mlock adds
+no meaningful protection).
+
 ## Initialization and unseal (manual, post-deployment)
 Vault standalone starts **sealed**. Unlike the managed-cloud offerings, this
 deployment has no auto-unseal configured (see "Production evolution" below),

--- a/k8s/vault/vault.yaml
+++ b/k8s/vault/vault.yaml
@@ -36,6 +36,7 @@ metadata:
 data:
   extraconfig-from-values.hcl: |-
     ui = true
+    disable_mlock = true
     
     listener "tcp" {
       tls_disable = 1
@@ -45,8 +46,6 @@ data:
     storage "raft" {
       path = "/vault/data"
     }
-    
-    disable_mlock = true
 ---
 # Source: vault/templates/injector-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -410,6 +409,9 @@ spec:
    
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           env:
             - name: HOST_IP
               valueFrom:


### PR DESCRIPTION
## Summary
- The `drop-all-capabilities` Kyverno ClusterPolicy blocked the `vault` StatefulSet sync (PR #102 deployed it, but the `vault` namespace is enforced — it is not in the kyverno infra exclusion list).
- Drop ALL capabilities on the server container (`server.statefulSet.securityContext.container`, which replaces the chart default, so `allowPrivilegeEscalation: false` is restated).
- Make `disable_mlock = true` explicit in the standalone config: no `IPC_LOCK` means mlock cannot work, and Vault >= 1.20 requires the setting with Integrated Storage anyway (the chart was already auto-appending it).

## Test plan
- [ ] ArgoCD `vault` Application reaches `Synced` after merge
- [ ] `vault-0` pod starts (0/1 Ready until unsealed — expected)