### PR TITLE
feat(vault): add in-cluster auto-unseal with vault-unsealer

### DIFF
--- a/adr/0006-vault-in-cluster-auto-unseal.md
+++ b/adr/0006-vault-in-cluster-auto-unseal.md
@@ -1,0 +1,76 @@
+# 0006 - Auto-unseal in-cluster de Vault avec vault-unsealer
+
+- Statut : Accepted
+- Date : 2026-07-02
+- Décideurs : équipe KubeQuest
+- PR : à compléter à l'ouverture
+
+## Contexte
+
+L'ADR [0005](0005-vault-secrets-management.md) a déployé Vault standalone en
+assumant l'absence d'auto-unseal comme dette technique : chaque redémarrage du
+pod re-scelle Vault et exige une intervention manuelle avec 3 des 5 clés
+Shamir. Or ce cluster est **éteint toutes les nuits** : sans automatisation,
+Vault redémarrerait scellé chaque matin, rendant indisponible tout futur
+consommateur de l'Injector jusqu'à une intervention humaine quotidienne —
+inacceptable même pour un cluster de démonstration.
+
+L'évolution "production" identifiée (auto-unseal `seal "awskms"`) reste
+bloquée par l'absence de wiring IAM dans l'infra Terraform.
+
+## Décision
+
+Déployer **[bakito/vault-unsealer](https://github.com/bakito/vault-unsealer)**
+(chart Helm 0.4.1, vendored manifest `k8s/vault/unsealer.yaml`, même
+Application ArgoCD que Vault) : un controller Kubernetes qui surveille, dans
+le namespace `vault`, les Secrets portant le label
+`vault-unsealer.bakito.net/stateful-set=vault` et déverrouille automatiquement
+les pods du StatefulSet avec les entrées `unsealKey*` du Secret.
+
+Le Secret `vault-unseal-keys` (3 des 5 clés, le seuil Shamir) est créé à la
+main hors Git, comme les autres secrets du cluster (`mysql-credentials`,
+`dex-clients`…). Il doit **persister** : le cluster étant éteint chaque nuit,
+un cache mémoire seul serait perdu à chaque arrêt.
+
+Critères de choix du projet : activité récente (v0.4.1, janvier 2026), Go,
+chart Helm vendorable selon le pattern du repo, RBAC scoped au namespace, et
+securityContext par défaut déjà conforme aux ClusterPolicies Kyverno
+enforced (drop ALL, runAsNonRoot, no privilege escalation, seccomp
+RuntimeDefault).
+
+## Alternatives envisagées
+
+- **Auto-unseal AWS KMS** (`seal "awskms"`) : toujours la cible production,
+  mais nécessite un rôle IAM pour le pod et une policy KMS absents de l'infra
+  Terraform actuelle. Reporté, inchangé depuis l'ADR 0005.
+- **Unseal manuel quotidien** (statu quo de l'ADR 0005) : rejeté — le cluster
+  éteint chaque nuit transforme la dette "intervention après incident" en
+  corvée quotidienne garantie.
+- **pyToshka/vault-autounseal** : gère aussi l'init automatique, mais projet
+  Python peu actif (dernière release août 2024) ; l'init automatique n'a
+  aucun intérêt ici (opération unique déjà faite).
+- **bank-vaults (vault-operator)** : operator complet qui remplacerait le
+  déploiement par chart officiel de l'ADR 0005 — disproportionné pour le
+  besoin.
+
+## Conséquences
+
+### Positives
+
+- Vault se déverrouille seul au démarrage matinal du cluster et après tout
+  redémarrage de pod (OOMKill, reschedule) : plus d'intervention quotidienne.
+- Reste dans le pattern vendored manifest + GitOps du repo ; le controller
+  est conforme aux policies Kyverno sans exception.
+
+### Négatives / points d'attention
+
+- **Le seal ne protège plus contre un attaquant in-cluster** : quiconque peut
+  lire les Secrets du namespace `vault` peut déverrouiller Vault. Le modèle
+  de menace couvert se réduit au vol du disque/volume seul (les données Raft
+  restent chiffrées au repos). Compromis assumé pour ce cluster de démo ;
+  l'auto-unseal KMS rétablirait une frontière de confiance externe.
+- Les clés d'unseal existent désormais à deux endroits : le gestionnaire de
+  mots de passe de l'équipe (les 5) et le Secret in-cluster (3 sur 5).
+- Dépendance à un projet communautaire de faible notoriété (9 étoiles) —
+  atténuée par la simplicité du fallback : `vault operator unseal` manuel
+  reste documenté dans `k8s/vault/README.md`.

--- a/adr/README.md
+++ b/adr/README.md
@@ -21,3 +21,4 @@ contexte et ses conséquences.
 | [0003](0003-native-multiarch-image-build.md) | Build multi-arch natif de l'image sample-app | Accepted |
 | [0004](0004-argo-rollouts-canary-deployment.md) | Déploiement canary et rollback automatique avec Argo Rollouts | Accepted |
 | [0005](0005-vault-secrets-management.md) | Gestion des secrets avec HashiCorp Vault (standalone + Raft) | Accepted |
+| [0006](0006-vault-in-cluster-auto-unseal.md) | Auto-unseal in-cluster de Vault avec vault-unsealer | Accepted |

--- a/argocd/apps/vault/application.yaml
+++ b/argocd/apps/vault/application.yaml
@@ -2,7 +2,8 @@
 # Injector enabled, synced by the root app-of-apps.
 #
 # vault.yaml = server + injector rendered from the official chart; ingress.yaml
-# = UI exposure at vault.kubequest.epitech.beer (issue: Vault secrets mgmt).
+# = UI exposure at vault.kubequest.epitech.beer (issue: Vault secrets mgmt);
+# unsealer.yaml = in-cluster auto-unseal controller (adr/0006).
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -19,7 +20,7 @@ spec:
     targetRevision: main
     path: k8s/vault
     directory:
-      include: "{vault.yaml,ingress.yaml}"
+      include: "{vault.yaml,ingress.yaml,unsealer.yaml}"
   destination:
     server: https://kubernetes.default.svc
     namespace: vault

--- a/helm/vault/unsealer-values.yaml
+++ b/helm/vault/unsealer-values.yaml
@@ -1,0 +1,30 @@
+# vault-unsealer values used to render k8s/vault/unsealer.yaml.
+# Regenerate the manifest with:
+#   helm repo add bakito https://bakito.github.io/helm-charts
+#   helm repo update bakito
+#   helm template vault-unsealer bakito/vault-unsealer \
+#     --version 0.4.1 \
+#     --namespace vault \
+#     --values helm/vault/unsealer-values.yaml \
+#     > k8s/vault/unsealer.yaml
+#
+# Pinned chart version: 0.4.1 (app version v0.4.1).
+#
+# In-cluster auto-unseal controller (see adr/0006): watches Secrets labelled
+# vault-unsealer.bakito.net/stateful-set=vault in this namespace and unseals
+# the vault pods with the unsealKey* entries whenever they start sealed. The
+# chart's default securityContext already satisfies the enforced kyverno
+# policies (drop ALL, runAsNonRoot, no privilege escalation).
+
+# Only values that DIFFER from the chart defaults live here; Helm deep-merges,
+# so untouched keys keep the maintainer's recommended values.
+
+# Trim requests for this small cluster (same rationale as helm/kyverno):
+# reserve less so the pod schedules easily, keep the chart's limits untouched.
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 512Mi

--- a/k8s/vault/README.md
+++ b/k8s/vault/README.md
@@ -59,29 +59,55 @@ config — required anyway by Vault >= 1.20 with Integrated Storage, and
 HashiCorp's recommendation for Raft (data already touches disk, mlock adds
 no meaningful protection).
 
-## Initialization and unseal (manual, post-deployment)
-Vault standalone starts **sealed**. Unlike the managed-cloud offerings, this
-deployment has no auto-unseal configured (see "Production evolution" below),
-so this is a one-time, then repeat-after-every-restart, manual procedure:
+## Initialization (manual, once) and auto-unseal
+Vault standalone starts **sealed**. Initialization is a one-time manual step:
 
 ```sh
 kubectl -n vault exec -it vault-0 -- vault operator init \
   -key-shares=5 -key-threshold=3
 # Store the 5 unseal keys and the root token somewhere safe, OUTSIDE Git.
 # Never commit real key/token values, even as "examples".
-
-kubectl -n vault exec -it vault-0 -- vault operator unseal <key1>
-kubectl -n vault exec -it vault-0 -- vault operator unseal <key2>
-kubectl -n vault exec -it vault-0 -- vault operator unseal <key3>
 ```
 
-Any of the 5 keys works as long as 3 distinct ones are supplied. Check status
-at any time with `kubectl -n vault exec -it vault-0 -- vault status`.
+Unsealing is handled by the in-cluster **vault-unsealer** controller
+(`k8s/vault/unsealer.yaml`, see [adr/0006](../../adr/0006-vault-in-cluster-auto-unseal.md)):
+it watches Secrets in this namespace labelled with the target StatefulSet
+name and unseals the vault pods whenever they start sealed — which on this
+cluster happens **every morning** (the nodes are shut down at night).
+
+Create the Secret once, by hand (out of Git, like `mysql-credentials`), with
+at least `-key-threshold` (3) of the 5 keys:
+
+```sh
+kubectl -n vault create secret generic vault-unseal-keys \
+  --from-literal=unsealKey1=<key1> \
+  --from-literal=unsealKey2=<key2> \
+  --from-literal=unsealKey3=<key3>
+kubectl -n vault label secret vault-unseal-keys \
+  vault-unsealer.bakito.net/stateful-set=vault
+```
+
+Check status at any time with
+`kubectl -n vault exec -it vault-0 -- vault status`. Manual fallback if the
+unsealer is ever broken: `vault operator unseal <key>` three times.
 
 > The pod's readiness probe expects Vault to be unsealed, so `vault-0` will
 > show `0/1 Ready` (and Argo CD will report the `vault` Application as
-> `Progressing`/`Degraded`) between deployment and the first unseal. This is
-> expected — not a sync failure.
+> `Progressing`/`Degraded`) between deployment and the first unseal, and
+> briefly after each restart until the unsealer acts. This is expected — not
+> a sync failure.
+
+### Regenerating the unsealer manifest
+```sh
+helm repo add bakito https://bakito.github.io/helm-charts
+helm repo update bakito
+helm template vault-unsealer bakito/vault-unsealer \
+  --version 0.4.1 \
+  --namespace vault \
+  --values helm/vault/unsealer-values.yaml \
+  > k8s/vault/unsealer.yaml
+```
+Pinned chart version: **0.4.1** (app version v0.4.1).
 
 ## Kubernetes auth method (Injector foundation, demo only)
 Enable the auth method Vault needs to validate Kubernetes ServiceAccount
@@ -146,12 +172,14 @@ No manual `kubectl apply` for the manifests — but init/unseal and the
 Kubernetes auth method setup above remain manual, out-of-Git steps.
 
 ## Production evolution
-- **No auto-unseal**: every pod restart (OOMKill, reschedule, node reboot)
-  re-seals Vault and requires a manual unseal with 3 of the 5 keys. The
-  robust evolution is `seal "awskms"` in the server config, which needs IAM
-  wiring (a role for the pod, a KMS key policy) not yet present in the
-  Terraform infra — same gap already noted for the AWS EBS CSI driver in
-  `k8s/mysql/README.md`.
+- **Auto-unseal keys live in-cluster**: the `vault-unseal-keys` Secret means
+  Vault's seal no longer protects against an attacker with cluster access —
+  anyone who can read Secrets in the `vault` namespace can unseal (see
+  adr/0006 for why this trade-off was accepted on this nightly-shutdown
+  cluster). The robust evolution is `seal "awskms"` in the server config,
+  which needs IAM wiring (a role for the pod, a KMS key policy) not yet
+  present in the Terraform infra — same gap already noted for the AWS EBS
+  CSI driver in `k8s/mysql/README.md`.
 - **No HA**: a single pod is a single point of failure. Multi-replica Raft
   HA is deliberately deferred until the cluster has more headroom.
 - **Secrets not yet migrated**: Vault currently coexists with the hand-created

--- a/k8s/vault/unsealer.yaml
+++ b/k8s/vault/unsealer.yaml
@@ -1,0 +1,211 @@
+---
+# Source: vault-unsealer/templates/rbac/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-unsealer
+  namespace: vault
+  labels:
+  
+    helm.sh/chart: vault-unsealer-0.4.1
+    helm.sh/namespace: vault
+    app.kubernetes.io/name: vault-unsealer
+    app.kubernetes.io/instance: vault-unsealer
+    app.kubernetes.io/version: "v0.4.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: vault-unsealer/templates/rbac/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vault-unsealer
+  namespace: vault
+  labels:
+
+    helm.sh/chart: vault-unsealer-0.4.1
+    helm.sh/namespace: vault
+    app.kubernetes.io/name: vault-unsealer
+    app.kubernetes.io/instance: vault-unsealer
+    app.kubernetes.io/version: "v0.4.1"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  # start leader election
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+
+# end leader election
+---
+# Source: vault-unsealer/templates/rbac/role_binding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vault-unsealer
+  namespace: vault
+  labels:
+
+    helm.sh/chart: vault-unsealer-0.4.1
+    helm.sh/namespace: vault
+    app.kubernetes.io/name: vault-unsealer
+    app.kubernetes.io/instance: vault-unsealer
+    app.kubernetes.io/version: "v0.4.1"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: vault-unsealer
+roleRef:
+  kind: Role
+  name: vault-unsealer
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: vault-unsealer/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault-unsealer
+  labels:
+    helm.sh/chart: vault-unsealer-0.4.1
+    helm.sh/namespace: vault
+    app.kubernetes.io/name: vault-unsealer
+    app.kubernetes.io/instance: vault-unsealer
+    app.kubernetes.io/version: "v0.4.1"
+    app.kubernetes.io/managed-by: Helm
+  namespace: vault
+spec:
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 8080
+      targetPort: metrics
+  selector:
+      app.kubernetes.io/name: vault-unsealer
+      app.kubernetes.io/instance: vault-unsealer
+---
+# Source: vault-unsealer/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault-unsealer
+  namespace: vault
+  labels:
+    helm.sh/chart: vault-unsealer-0.4.1
+    helm.sh/namespace: vault
+    app.kubernetes.io/name: vault-unsealer
+    app.kubernetes.io/instance: vault-unsealer
+    app.kubernetes.io/version: "v0.4.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vault-unsealer
+      app.kubernetes.io/instance: vault-unsealer
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vault-unsealer
+        app.kubernetes.io/instance: vault-unsealer
+    spec:
+      serviceAccountName: vault-unsealer
+      containers:
+        - name: vault-unsealer
+          image: 'ghcr.io/bakito/vault-unsealer:v0.4.1'
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/go/vault-unsealer
+          env:
+            - name: UNSEALER_DEPLOYMENT_NAME
+              value: vault-unsealer
+            - name: UNSEALER_SERVICE_NAME
+              value: vault-unsealer
+            - name: UNSEALER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: UNSEALER_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: UNSEALER_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          args:
+            - '-leader-elect'
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 25m
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          ports:
+            - containerPort: 8080
+              name: metrics
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault


### PR DESCRIPTION
## Summary
- The cluster is shut down nightly, so standalone Vault (PR #102) would restart **sealed every morning**, requiring a manual 3-key unseal daily.
- Deploy [bakito/vault-unsealer](https://github.com/bakito/vault-unsealer) (chart 0.4.1, vendored manifest `k8s/vault/unsealer.yaml`, same ArgoCD Application via glob brace): a namespace-scoped controller that watches Secrets labelled `vault-unsealer.bakito.net/stateful-set=vault` and unseals the vault pods with their `unsealKey*` entries.
- The `vault-unseal-keys` Secret (3 of 5 Shamir keys) is created by hand, out of Git — same pattern as `mysql-credentials`.
- Chart defaults already satisfy the enforced Kyverno policies (drop ALL, runAsNonRoot, no privilege escalation, seccomp RuntimeDefault); only CPU/memory requests are trimmed for this cluster.
- Trade-off documented in `adr/0006-vault-in-cluster-auto-unseal.md`: the seal no longer protects against cluster-level access; AWS KMS auto-unseal remains the production evolution.

## Test plan
- [ ] ArgoCD `vault` Application reaches `Synced`, `vault-unsealer` pod Running (not blocked by Kyverno)
- [ ] `vault operator init` (manual, once), then create the labelled `vault-unseal-keys` Secret
- [ ] The unsealer performs the first unseal: `vault-0` becomes `1/1 Ready` without any manual `vault operator unseal`
- [ ] Delete the vault pod and verify it is auto-unsealed again after restart