### PR TITLE
fix(vault): return to the protected host after SSO login

### DIFF
--- a/k8s/oauth2-proxy/README.md
+++ b/k8s/oauth2-proxy/README.md
@@ -40,8 +40,14 @@ itself:
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-url: "https://auth.kubequest.epitech.beer/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://auth.kubequest.epitech.beer/oauth2/start?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.kubequest.epitech.beer/oauth2/start?rd=$scheme://$host$escaped_request_uri"
 ```
+
+> The `rd` parameter must carry `$scheme://$host`, not just the escaped path:
+> the proxy lives on its own sub-domain, so a path-only `rd` would redirect
+> the user to `auth.kubequest.epitech.beer/<path>` after login instead of
+> back to the protected tool. (Found the hard way when Vault became the first
+> real consumer — see `k8s/vault/ingress.yaml`.)
 
 That's the whole opt-in. Because the session cookie is scoped to the parent
 domain (`--cookie-domain=.kubequest.epitech.beer`), one login covers every

--- a/k8s/vault/README.md
+++ b/k8s/vault/README.md
@@ -87,6 +87,11 @@ kubectl -n vault label secret vault-unseal-keys \
   vault-unsealer.bakito.net/stateful-set=vault
 ```
 
+> The unsealer only loads the keys Secret **at startup**: if the Secret is
+> created (or changed) while the controller is already running, restart it —
+> `kubectl -n vault rollout restart deploy/vault-unsealer` — so it picks the
+> keys up and performs the unseal.
+
 Check status at any time with
 `kubectl -n vault exec -it vault-0 -- vault status`. Manual fallback if the
 unsealer is ever broken: `vault operator unseal <key>` three times.

--- a/k8s/vault/ingress.yaml
+++ b/k8s/vault/ingress.yaml
@@ -17,7 +17,11 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/auth-url: "https://auth.kubequest.epitech.beer/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://auth.kubequest.epitech.beer/oauth2/start?rd=$escaped_request_uri"
+    # rd must carry scheme+host, not just the path: oauth2-proxy lives on its
+    # own sub-domain, so a path-only rd would strand the user on auth.* after
+    # login instead of coming back here. whitelist-domain on the proxy side
+    # already allows *.kubequest.epitech.beer redirects.
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.kubequest.epitech.beer/oauth2/start?rd=$scheme://$host$escaped_request_uri"
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Summary
- The `auth-signin` annotation's `rd` parameter only carried `$escaped_request_uri` (the path): after logging in on Dex, the user was stranded on `auth.kubequest.epitech.beer/` instead of returning to Vault. Spotted live on the first real use of the forward-auth mechanism.
- Prefix `rd` with `$scheme://$host` — the canonical form in the oauth2-proxy docs when the proxy lives on its own sub-domain. `whitelist-domain=.kubequest.epitech.beer` already allows the cross-sub-domain redirect on the proxy side.
- Fix the same annotation documented in `k8s/oauth2-proxy/README.md` ("Protecting a future tool"), which had never been exercised before Vault.
- Document in `k8s/vault/README.md` that vault-unsealer only loads the keys Secret at startup (restart the controller if the Secret is created afterwards) — observed during rollout.

## Test plan
- [ ] `curl -sI https://vault.kubequest.epitech.beer` still 302s to `/oauth2/start` with `rd=https%3A%2F%2Fvault.kubequest.epitech.beer%2F`
- [ ] Browser: GitHub login then redirect back to the Vault UI (not auth.*)