### PR TITLE
feat(kuard): demo workload for OOM/CPU limits and canary rollback

### DIFF
--- a/argocd/apps/kuard/application.yaml
+++ b/argocd/apps/kuard/application.yaml
@@ -1,0 +1,34 @@
+# kuard — demo workload for the monitoring soutenance, synced by the root
+# app-of-apps.
+#
+# Unlike sample-app (chart published as an OCI artifact by CI), this chart has
+# no image build of its own (upstream gcr.io/kuar-demo image), so Argo CD
+# renders it straight from this Git repo (path: helm/kuard). Deployment values
+# ARE the chart defaults: to run the rollback demo, flip `forceUnhealthy` in
+# helm/kuard/values.yaml and commit — see helm/kuard/README.md.
+#
+# Wave 1: needs the Argo Rollouts CRDs (wave -1) and cert-manager/ingress.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kuard
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/T-CLO-902-KubeQuest/KubeQuest.git
+    targetRevision: main
+    path: helm/kuard
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kuard
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/apps/monitoring/application.yaml
+++ b/argocd/apps/monitoring/application.yaml
@@ -24,8 +24,9 @@ spec:
       # (Deployment + Service + ServiceMonitor) pour le 2e critère d'acceptation.
       # loki.yaml/promtail.yaml = agrégation de logs (#15) ; grafana-ingress.yaml
       # = exposition Grafana (#14) ; loki-dashboard.yaml = dashboard logs custom ;
-      # soutenance-dashboard.yaml = dashboard de démo scaling/santé/logs (#23/#24).
-      include: "{monitoring.yaml,example-app.yaml,loki.yaml,promtail.yaml,grafana-ingress.yaml,loki-dashboard.yaml,soutenance-dashboard.yaml}"
+      # soutenance-dashboard.yaml = dashboard de démo scaling/santé/logs (#23/#24) ;
+      # kuard-dashboard.yaml = dashboard de démo OOM/CPU limits/rollback (kuard).
+      include: "{monitoring.yaml,example-app.yaml,loki.yaml,promtail.yaml,grafana-ingress.yaml,loki-dashboard.yaml,soutenance-dashboard.yaml,kuard-dashboard.yaml}"
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring

--- a/helm/kuard/Chart.yaml
+++ b/helm/kuard/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: kuard
+description: kuard (Kubernetes Up And Running Demo) — demo workload for the monitoring/rollback live demo
+type: application
+version: 0.1.0
+# Tracks the upstream image tag (gcr.io/kuar-demo/kuard-amd64). The colored
+# tags (blue/green/purple) make a canary rollout visually obvious in the UI.
+appVersion: "blue"

--- a/helm/kuard/README.md
+++ b/helm/kuard/README.md
@@ -1,0 +1,46 @@
+# kuard — workload de démo monitoring
+
+Déploie [kuard](https://github.com/kubernetes-up-and-running/kuard) (l'app de
+démo de *Kubernetes Up and Running*) via un `Rollout` Argo Rollouts, avec des
+limits volontairement serrées. Synchronisé par Argo CD depuis ce repo
+(`argocd/apps/kuard/application.yaml`, namespace `kuard`), exposé sur
+<https://kuard.kubequest.epitech.beer>.
+
+Dashboard Grafana associé : **« Demo kuard - OOM / CPU limits / rollback »**
+(uid `kuard-demo`, provisionné par `k8s/monitoring/kuard-dashboard.yaml`).
+
+## Démo 1 — OOMKill et relance automatique
+
+1. Ouvrir le dashboard Grafana (rangée « Mémoire vs limit ») à côté de l'UI kuard.
+2. Dans kuard, onglet **Memory** (`/mem`) : allouer de la mémoire par blocs
+   jusqu'à dépasser la limit de 128 Mi (≈ 2×128 MiB suffisent).
+3. Le kernel OOMKill le conteneur : le pod passe brièvement en
+   `CrashLoopBackOff` puis est relancé par le kubelet. Sur le dashboard :
+   working set qui monte jusqu'à la limit, stat « Pods OOMKilled » à 1,
+   restarts qui s'incrémentent.
+
+## Démo 2 — CPU limit et throttling
+
+1. Dans kuard, onglet **KeyGen Workload** : activer le workload (génération de
+   clés SSH en boucle).
+2. Sur le dashboard : l'usage CPU plafonne à la limit (200m) et le panel
+   « CPU throttling » monte vers 100 % — le conteneur est bridé par CFS, pas
+   tué.
+3. Désactiver le workload pour revenir à la normale.
+
+## Démo 3 — Rollback automatique (forceUnhealthy)
+
+Même mécanisme que `helm/sample-app` : un canary cassé échoue l'analyse et
+Argo Rollouts revient au ReplicaSet stable.
+
+1. Dans `helm/kuard/values.yaml`, passer `forceUnhealthy: true`, committer sur
+   `main` : Argo CD sync, le Rollout démarre un canary dont la readinessProbe
+   pointe sur un chemin inexistant (404) — il ne devient jamais Ready.
+2. L'`AnalysisTemplate` sonde le Service canary (`kuard-kuard-canary`), sans
+   endpoint Ready chaque mesure échoue ; après 2 échecs le Rollout **abort** et
+   rollback vers la version stable (`kubectl argo rollouts get rollout
+   kuard-kuard -n kuard --watch` pour le suivi).
+3. Remettre `forceUnhealthy: false` et committer.
+
+Variante visuelle sans casser quoi que ce soit : changer `image.tag` de `blue`
+à `green` — le canary sain est promu et la bannière de l'UI change de couleur.

--- a/helm/kuard/templates/_helpers.tpl
+++ b/helm/kuard/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{- define "kuard.name" -}}
+{{- .Chart.Name }}
+{{- end }}
+
+{{- define "kuard.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "kuard.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ include "kuard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "kuard.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kuard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/kuard/templates/analysistemplate.yaml
+++ b/helm/kuard/templates/analysistemplate.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: {{ include "kuard.fullname" . }}-canary-health
+  labels:
+    {{- include "kuard.labels" . | nindent 4 }}
+spec:
+  metrics:
+    - name: canary-health
+      # Give the canary time to boot and pass its readinessProbe before the
+      # first measurement.
+      initialDelay: 30s
+      interval: 15s
+      count: 4
+      # No successCondition: the web provider succeeds on any 2xx. A canary
+      # that never becomes Ready (forceUnhealthy) leaves the canary Service
+      # without endpoints, so every request errors; past failureLimit the
+      # AnalysisRun fails -> the Rollout aborts and rolls back to stable.
+      failureLimit: 2
+      provider:
+        web:
+          # Canary-only Service (selector managed by Argo Rollouts), so the
+          # stable pods cannot mask a broken canary.
+          url: http://{{ include "kuard.fullname" . }}-canary.{{ .Release.Namespace }}.svc.cluster.local/healthy
+          timeoutSeconds: 5

--- a/helm/kuard/templates/ingress.yaml
+++ b/helm/kuard/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kuard.fullname" . }}
+  labels:
+    {{- include "kuard.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" (include "kuard.fullname" .)) }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "kuard.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/helm/kuard/templates/rollout.yaml
+++ b/helm/kuard/templates/rollout.yaml
@@ -1,0 +1,77 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ include "kuard.fullname" . }}
+  labels:
+    {{- include "kuard.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kuard.selectorLabels" . | nindent 6 }}
+  # A canary that never reaches Ready (forceUnhealthy) keeps the Rollout
+  # Progressing; Argo Rollouts marks it Degraded past this deadline.
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+  strategy:
+    canary:
+      # Argo Rollouts rewrites this Service's selector so it only fronts the
+      # canary pods; the analysis below probes it, so only the canary's health
+      # decides promotion vs rollback (the stable pods can't mask a broken
+      # canary).
+      canaryService: {{ include "kuard.fullname" . }}-canary
+      stableService: {{ include "kuard.fullname" . }}
+      analysis:
+        startingStep: {{ .Values.canary.analysis.startingStep }}
+        templates:
+          - templateName: {{ include "kuard.fullname" . }}-canary-health
+      steps:
+        {{- toYaml .Values.canary.steps | nindent 8 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kuard.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: kuard
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          # Liveness stays on /healthy: after an OOMKill the kubelet restarts
+          # the container regardless, this just covers a hung process.
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          # Demo hook: with forceUnhealthy the probe targets a path kuard does
+          # not serve (404), so the pod never becomes Ready and the canary
+          # analysis fails => automatic rollback.
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.forceUnhealthy | ternary "/force-unhealthy" "/ready" }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}

--- a/helm/kuard/templates/service.yaml
+++ b/helm/kuard/templates/service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kuard.fullname" . }}
+  labels:
+    {{- include "kuard.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "kuard.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: http
+---
+# Canary-only Service: Argo Rollouts narrows its selector to the canary
+# ReplicaSet's pod-template-hash during a rollout (see canaryService in
+# rollout.yaml). The AnalysisTemplate probes it to judge the canary alone.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kuard.fullname" . }}-canary
+  labels:
+    {{- include "kuard.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "kuard.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/helm/kuard/values.yaml
+++ b/helm/kuard/values.yaml
@@ -1,0 +1,78 @@
+replicaCount: 2
+
+image:
+  # Upstream demo image from "Kubernetes Up and Running". The blue/green/purple
+  # tags serve the same app with a different banner color, which makes a canary
+  # rollout (and its rollback) visible at a glance in the browser.
+  repository: gcr.io/kuar-demo/kuard-amd64
+  # Empty by default: falls back to Chart.appVersion ("blue").
+  tag: ""
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: nginx
+  host: kuard.kubequest.epitech.beer
+  path: /
+  pathType: Prefix
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  tls:
+    enabled: true
+    # Defaults to "<fullname>-tls" when empty.
+    secretName: ""
+
+# Deliberately tight limits: the whole point of this workload is to demo what
+# happens when they are hit.
+#   - Memory: kuard idles around 10-20 MiB; allocating ~256 MiB from its /mem
+#     page blows through the 128 Mi limit => OOMKilled => restart (visible on
+#     the Grafana "kuard demo" dashboard).
+#   - CPU: enabling the KeyGen workload from the kuard UI saturates the 200m
+#     limit => CFS throttling (also graphed on the dashboard).
+resources:
+  requests:
+    cpu: 50m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+# Argo Rollouts canary strategy, same mechanism as sample-app: the analysis
+# probes the canary-only Service; if the canary never becomes Ready (e.g.
+# forceUnhealthy below), the AnalysisRun fails and the Rollout aborts back to
+# the stable ReplicaSet.
+canary:
+  steps:
+    - setWeight: 50
+    - pause:
+        duration: 60s
+  analysis:
+    startingStep: 0
+
+# Keep greater than the sum of the canary pauses above.
+progressDeadlineSeconds: 180
+
+# Demo hook, same idea as sample-app's app.forceUnhealthy: when true, the
+# readinessProbe targets a path kuard does not serve (404), so the canary pods
+# never become Ready, the canary Service has no endpoints, the analysis web
+# probe fails and Argo Rollouts rolls back automatically. Flip it to true in
+# Git, watch the rollback, flip it back.
+forceUnhealthy: false
+
+nodeSelector: {}
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: kuard
+          topologyKey: kubernetes.io/hostname
+
+tolerations: []

--- a/k8s/cert-manager/README.md
+++ b/k8s/cert-manager/README.md
@@ -62,7 +62,11 @@ hosts {
    18.158.153.65 argocd.kubequest.epitech.beer
    18.158.153.65 headlamp.kubequest.epitech.beer
    18.158.153.65 dex.kubequest.epitech.beer
+   18.158.153.65 auth.kubequest.epitech.beer
    18.158.153.65 grafana.kubequest.epitech.beer
+   18.158.153.65 app.kubequest.epitech.beer
+   18.158.153.65 vault.kubequest.epitech.beer
+   18.158.153.65 kuard.kubequest.epitech.beer
    fallthrough
 }
 ```

--- a/k8s/monitoring/kuard-dashboard.yaml
+++ b/k8s/monitoring/kuard-dashboard.yaml
@@ -1,0 +1,213 @@
+# Dashboard Grafana « Demo kuard — OOM, CPU throttling, restarts, rollback ».
+#
+# Compagnon du workload de démo kuard (helm/kuard, namespace `kuard`). Il met
+# côte à côte la cause et l'effet pendant la démo live :
+#
+#   - OOMKill : mémoire working set vs limit (128 Mi) — allouer ~256 MiB depuis
+#     la page /mem de kuard fait franchir la limite => OOMKilled + restart ;
+#   - CPU limits : usage vs limit (200m) + ratio de throttling CFS — activer le
+#     KeyGen workload depuis l'UI kuard sature la limit ;
+#   - Crash & relances : restarts par pod, raison du dernier arrêt (OOMKilled),
+#     CrashLoopBackOff ;
+#   - Rollout / rollback : pods Ready vs desired, pour visualiser le canary qui
+#     échoue (forceUnhealthy: true) et le rollback Argo Rollouts.
+#
+# Chargé automatiquement par le sidecar dashboards de Grafana (label
+# grafana_dashboard: "1", namespace monitoring), comme soutenance-dashboard.yaml.
+# Datasources : Prometheus (uid "prometheus") et Loki (uid "loki").
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuard-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  kuard.json: |-
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "graphTooltip": 1,
+      "schemaVersion": 39,
+      "tags": ["soutenance", "kuard", "demo"],
+      "title": "Demo kuard - OOM / CPU limits / rollback",
+      "uid": "kuard-demo",
+      "time": { "from": "now-15m", "to": "now" },
+      "refresh": "10s",
+      "templating": {
+        "list": [
+          {
+            "name": "namespace",
+            "label": "Namespace",
+            "type": "constant",
+            "query": "kuard",
+            "current": { "text": "kuard", "value": "kuard" },
+            "hide": 2
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "title": "Crash & relances",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+        },
+        {
+          "type": "stat",
+          "title": "Restarts (15m)",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 6, "w": 4, "x": 0, "y": 1 },
+          "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } } },
+          "options": { "colorMode": "value", "graphMode": "area", "textMode": "value" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"$namespace\"}[15m]))",
+              "legendFormat": "restarts"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "Pods OOMKilled (dernier arret)",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 6, "w": 4, "x": 4, "y": 1 },
+          "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } } },
+          "options": { "colorMode": "value", "graphMode": "none", "textMode": "value" },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum(kube_pod_container_status_last_terminated_reason{namespace=\"$namespace\", reason=\"OOMKilled\"}) or vector(0)",
+              "legendFormat": "OOMKilled"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Restarts par pod",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 6, "w": 8, "x": 8, "y": 1 },
+          "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60 } } },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum by (pod) (increase(kube_pod_container_status_restarts_total{namespace=\"$namespace\"}[5m]))",
+              "legendFormat": "{{pod}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Raison d'attente (CrashLoopBackOff, ...)",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 6, "w": 8, "x": 16, "y": 1 },
+          "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "fillOpacity": 20 } } },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum by (reason) (kube_pod_container_status_waiting_reason{namespace=\"$namespace\"} == 1)",
+              "legendFormat": "{{reason}}"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "title": "Memoire vs limit (demo OOM via /mem)",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 }
+        },
+        {
+          "type": "timeseries",
+          "title": "Working set par pod vs limit (128 Mi)",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+          "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"$namespace\", container=\"kuard\"})",
+              "legendFormat": "{{pod}}"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "max(kube_pod_container_resource_limits{namespace=\"$namespace\", container=\"kuard\", resource=\"memory\"})",
+              "legendFormat": "limit / pod"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "CPU par pod vs limit (200m) - demo KeyGen",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container=\"kuard\"}[2m]))",
+              "legendFormat": "{{pod}}"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "max(kube_pod_container_resource_limits{namespace=\"$namespace\", container=\"kuard\", resource=\"cpu\"})",
+              "legendFormat": "limit / pod"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "CPU throttling (part des periodes CFS throttlees)",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 16 },
+          "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 20 } } },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace=\"$namespace\", container=\"kuard\"}[2m])) / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace=\"$namespace\", container=\"kuard\"}[2m]))",
+              "legendFormat": "{{pod}}"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Rollout : pods Ready vs desired (canary / rollback)",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 16 },
+          "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "fillOpacity": 10 } } },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum(kube_pod_status_ready{namespace=\"$namespace\", condition=\"true\"})",
+              "legendFormat": "ready"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "count(kube_pod_status_phase{namespace=\"$namespace\", phase=\"Running\"} == 1)",
+              "legendFormat": "running"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum(kube_replicaset_spec_replicas{namespace=\"$namespace\"})",
+              "legendFormat": "desired (replicasets)"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "title": "Logs kuard (live)",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 }
+        },
+        {
+          "type": "logs",
+          "title": "Logs kuard (Loki)",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "gridPos": { "h": 9, "w": 24, "x": 0, "y": 24 },
+          "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending", "enableLogDetails": true },
+          "targets": [
+            {
+              "datasource": { "type": "loki", "uid": "loki" },
+              "expr": "{namespace=\"$namespace\"}"
+            }
+          ]
+        }
+      ]
+    }


### PR DESCRIPTION
## Summary

- **`helm/kuard`**: new in-repo Helm chart for [kuard](https://github.com/kubernetes-up-and-running/kuard), the monitoring demo workload. Argo Rollouts canary with an `AnalysisTemplate` probing a **dedicated canary Service**, so stable pods cannot mask a broken canary. Deliberately tight limits (128Mi / 200m) so OOMKill and CFS throttling are easy to trigger from the kuard UI (`/mem`, KeyGen workload). `forceUnhealthy` flag (same idea as sample-app) drives the automatic-rollback demo — see `helm/kuard/README.md` for the three demo scenarios.
- **`argocd/apps/kuard`**: Application rendered straight from Git (`path: helm/kuard`), namespace `kuard`, wave 1, picked up by the root app-of-apps.
- **`k8s/monitoring/kuard-dashboard.yaml`**: dedicated Grafana dashboard (uid `kuard-demo`) — restarts, OOMKilled stat, CrashLoopBackOff, memory/CPU vs limits, CFS throttling ratio, rollout ready-vs-desired, Loki logs. Added to the monitoring Application `include` list.
- **`k8s/cert-manager/README.md`**: CoreDNS `hosts` example block resynced with the live cluster (auth/app/vault were missing) + kuard entry.

## Already done out-of-band

- CoreDNS `hosts` entry `18.158.153.65 kuard.kubequest.epitech.beer` applied live and verified in-cluster (cert-manager HTTP-01 self-check).
- Public A record created at the registrar and propagated (1.1.1.1 / 8.8.8.8).

## After merge

Argo CD deploys everything automatically: kuard at https://kuard.kubequest.epitech.beer (cert issued by letsencrypt-prod) and the dashboard hot-loaded by the Grafana sidecar.