### PR TITLE
fix(kuard): build multi-arch images for the arm64 nodes

### DIFF
--- a/.github/workflows/kuard-mirror.yml
+++ b/.github/workflows/kuard-mirror.yml
@@ -38,12 +38,29 @@ jobs:
           git clone "$KUARD_REPO" kuard
           git -C kuard checkout "$KUARD_COMMIT"
 
-      - name: Inject color version into the Dockerfile
-        # The stock Dockerfile hardcodes ENV VERSION=test; turn it into a
-        # build-arg so the binary reports 1-<color> and the UI picks the color.
+      - name: Patch the Dockerfile (color version + multi-arch)
+        # The stock Dockerfile hardcodes ENV VERSION=test and ENV ARCH=amd64.
+        #   - VERSION becomes a build-arg so the binary reports 1-<color> and
+        #     the UI picks the color;
+        #   - the build stage is pinned to the runner platform and
+        #     cross-compiles via GOARCH=$TARGETARCH (the cluster nodes are
+        #     arm64 Graviton), with no QEMU emulation of the Go/npm build;
+        #   - `go install` drops cross-compiled binaries in
+        #     /go/bin/linux_<arch>/, so normalize the path for the COPY.
         run: |
-          sed -i 's/^ENV VERSION=test$/ARG FAKE_VERSION=blue\nENV VERSION=1-${FAKE_VERSION}/' kuard/Dockerfile
-          grep -A1 'ARG FAKE_VERSION' kuard/Dockerfile
+          sed -i \
+            -e 's|^FROM golang:1.12-alpine AS build$|FROM --platform=$BUILDPLATFORM golang:1.12-alpine AS build|' \
+            -e 's|^ENV ARCH=amd64$|ARG TARGETARCH\nENV ARCH=${TARGETARCH}|' \
+            -e 's|^ENV VERSION=test$|ARG FAKE_VERSION=blue\nENV VERSION=1-${FAKE_VERSION}|' \
+            -e 's|^RUN build/build.sh$|RUN build/build.sh \&\& (cp -f /go/bin/linux_${ARCH}/kuard /go/bin/kuard \|\| true)|' \
+            kuard/Dockerfile
+          cat kuard/Dockerfile
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Compute image name (GHCR is lowercase-only)
         id: image
@@ -61,6 +78,8 @@ jobs:
         with:
           context: kuard
           push: true
+          # arm64 for the Graviton cluster nodes, amd64 for local runs.
+          platforms: linux/arm64,linux/amd64
           build-args: |
             FAKE_VERSION=${{ matrix.color }}
           tags: ${{ steps.image.outputs.name }}:${{ matrix.color }}


### PR DESCRIPTION
The kuard mirror images were amd64-only while the cluster nodes are arm64 (Graviton) — pods crashed with `exec format error`.

- Build stage pinned to `$BUILDPLATFORM` and cross-compiles with `GOARCH=$TARGETARCH` (no QEMU emulation of the Go/npm build, same spirit as the sample-app per-arch builds).
- `go install` drops cross-compiled binaries under `/go/bin/linux_<arch>/`, normalized before the runtime COPY.
- Pushes a `linux/arm64,linux/amd64` manifest for the blue/green/purple tags.

After merge: re-run the workflow; the crashing pods will pull the new digest and the Rollout recovers.