### PR TITLE
fix(kuard): always pull the mutable color tags

### DIFF
--- a/helm/kuard/values.yaml
+++ b/helm/kuard/values.yaml
@@ -9,7 +9,9 @@ image:
   repository: ghcr.io/t-clo-902-kubequest/kubequest/kuard
   # Empty by default: falls back to Chart.appVersion ("blue").
   tag: ""
-  pullPolicy: IfNotPresent
+  # The color tags are mutable (re-published by kuard-mirror.yml), so always
+  # resolve the current digest instead of trusting the node cache.
+  pullPolicy: Always
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Last piece of the kuard recovery: the nodes cached the broken amd64 image under the `blue` tag, and `IfNotPresent` never re-pulls, so the multi-arch rebuild (#110, published and verified `linux/arm64 + linux/amd64`) would never reach the pods. Color tags are mutable by design, so `pullPolicy: Always` is the correct setting.