### PR TITLE
feat(kuard): per-pod RAM usage gauge on the demo dashboard

### DIFF
--- a/k8s/monitoring/kuard-dashboard.yaml
+++ b/k8s/monitoring/kuard-dashboard.yaml
@@ -169,10 +169,26 @@ data:
           ]
         },
         {
+          "type": "bargauge",
+          "title": "RAM utilisee par pod (% de la limit)",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "gridPos": { "h": 4, "w": 24, "x": 0, "y": 16 },
+          "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 0.7 }, { "color": "red", "value": 0.9 } ] } } },
+          "options": { "orientation": "horizontal", "displayMode": "gradient", "showUnfilled": true },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"$namespace\", container=\"kuard\"}) / on (pod) sum by (pod) (kube_pod_container_resource_limits{namespace=\"$namespace\", container=\"kuard\", resource=\"memory\"})",
+              "legendFormat": "{{pod}}",
+              "instant": true
+            }
+          ]
+        },
+        {
           "type": "timeseries",
           "title": "CPU throttling (part des periodes CFS throttlees)",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 16 },
+          "gridPos": { "h": 7, "w": 12, "x": 0, "y": 20 },
           "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 20 } } },
           "targets": [
             {
@@ -186,7 +202,7 @@ data:
           "type": "timeseries",
           "title": "Rollout : pods Ready vs desired (canary / rollback)",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 16 },
+          "gridPos": { "h": 7, "w": 12, "x": 12, "y": 20 },
           "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "fillOpacity": 10 } } },
           "targets": [
             {
@@ -209,13 +225,13 @@ data:
         {
           "type": "row",
           "title": "Logs kuard (live)",
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 }
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }
         },
         {
           "type": "logs",
           "title": "Logs kuard (Loki)",
           "datasource": { "type": "loki", "uid": "loki" },
-          "gridPos": { "h": 9, "w": 24, "x": 0, "y": 24 },
+          "gridPos": { "h": 9, "w": 24, "x": 0, "y": 28 },
           "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending", "enableLogDetails": true },
           "targets": [
             {


### PR DESCRIPTION
Adds a full-width horizontal bar gauge "RAM utilisée par pod (% de la limit)" to the memory row: working set / memory limit per pod, green → yellow (70%) → red (90%). During the OOM demo the presenter sees the gauge climb into the red right before the OOMKill. Panels below are shifted down accordingly.