### PR TITLE
demo(kuard): trigger the canary rollback (forceUnhealthy)

### DIFF
--- a/helm/kuard/values.yaml
+++ b/helm/kuard/values.yaml
@@ -65,7 +65,7 @@ progressDeadlineSeconds: 180
 # never become Ready, the canary Service has no endpoints, the analysis web
 # probe fails and Argo Rollouts rolls back automatically. Flip it to true in
 # Git, watch the rollback, flip it back.
-forceUnhealthy: false
+forceUnhealthy: true
 
 nodeSelector: {}
 


### PR DESCRIPTION
Rehearsal of the rollback demo: flips `forceUnhealthy` to true so the canary never becomes Ready, the analysis fails and Argo Rollouts aborts back to stable. Will be reverted right after the test.