### PR TITLE
fix(kuard): detect a never-Ready canary via Prometheus analysis

### DIFF
--- a/helm/kuard/templates/analysistemplate.yaml
+++ b/helm/kuard/templates/analysistemplate.yaml
@@ -5,21 +5,30 @@ metadata:
   labels:
     {{- include "kuard.labels" . | nindent 4 }}
 spec:
+  # Injected by the Rollout (podTemplateHashValue: Latest): the pod-template
+  # hash of the canary ReplicaSet under analysis.
+  args:
+    - name: canary-hash
   metrics:
-    - name: canary-health
+    - name: canary-ready
       # Give the canary time to boot and pass its readinessProbe before the
       # first measurement.
       initialDelay: 30s
       interval: 15s
       count: 4
-      # No successCondition: the web provider succeeds on any 2xx. A canary
-      # that never becomes Ready (forceUnhealthy) leaves the canary Service
-      # without endpoints, so every request errors; past failureLimit the
-      # AnalysisRun fails -> the Rollout aborts and rolls back to stable.
+      # Measure the canary ReplicaSet's Ready replicas straight from
+      # kube-state-metrics (ReplicaSet name = <rollout>-<hash>). A web probe
+      # against the canary Service cannot catch a never-Ready canary: Argo
+      # Rollouts only flips that Service's selector to the canary hash once the
+      # canary has available pods, so the probe would keep hitting the healthy
+      # stable pods and pass. A broken canary (forceUnhealthy / crashing image)
+      # stays at 0 Ready => the AnalysisRun fails past failureLimit => the
+      # Rollout aborts and rolls back to stable.
+      successCondition: "len(result) > 0 && result[0] >= 1"
       failureLimit: 2
       provider:
-        web:
-          # Canary-only Service (selector managed by Argo Rollouts), so the
-          # stable pods cannot mask a broken canary.
-          url: http://{{ include "kuard.fullname" . }}-canary.{{ .Release.Namespace }}.svc.cluster.local/healthy
-          timeoutSeconds: 5
+        prometheus:
+          address: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+          query: >-
+            sum(kube_replicaset_status_ready_replicas{namespace="{{ .Release.Namespace }}",
+            replicaset="{{ include "kuard.fullname" . }}-{{`{{args.canary-hash}}`}}"})

--- a/helm/kuard/templates/rollout.yaml
+++ b/helm/kuard/templates/rollout.yaml
@@ -24,6 +24,10 @@ spec:
         startingStep: {{ .Values.canary.analysis.startingStep }}
         templates:
           - templateName: {{ include "kuard.fullname" . }}-canary-health
+        args:
+          - name: canary-hash
+            valueFrom:
+              podTemplateHashValue: Latest
       steps:
         {{- toYaml .Values.canary.steps | nindent 8 }}
   template:

--- a/helm/kuard/values.yaml
+++ b/helm/kuard/values.yaml
@@ -65,7 +65,7 @@ progressDeadlineSeconds: 180
 # never become Ready, the canary Service has no endpoints, the analysis web
 # probe fails and Argo Rollouts rolls back automatically. Flip it to true in
 # Git, watch the rollback, flip it back.
-forceUnhealthy: true
+forceUnhealthy: false
 
 nodeSelector: {}
 


### PR DESCRIPTION
Found during the rollback rehearsal: the web-provider analysis probed the canary Service, but Argo Rollouts only flips that Service's selector to the canary hash once the canary has **available** pods. A never-Ready canary (forceUnhealthy) left the probe hitting the healthy stable pods — the AnalysisRun passed (`ok` ×4) and no rollback happened; the Rollout just went Degraded on ProgressDeadlineExceeded with the canary hanging.

Fix: measure `kube_replicaset_status_ready_replicas` of the canary ReplicaSet (hash injected via `podTemplateHashValue: Latest`, ReplicaSet name = `<rollout>-<hash>`) from Prometheus. Verified against live data: canary RS returns 0, stable RS returns 2. A broken canary fails the analysis past `failureLimit` and the Rollout aborts back to stable.

Also resets `forceUnhealthy: false` (rehearsal cleanup); the rollback test will be re-run after merge.