### PR TITLE
demo(kuard): re-run the canary rollback rehearsal

### DIFF
--- a/helm/kuard/values.yaml
+++ b/helm/kuard/values.yaml
@@ -65,7 +65,7 @@ progressDeadlineSeconds: 180
 # never become Ready, the canary Service has no endpoints, the analysis web
 # probe fails and Argo Rollouts rolls back automatically. Flip it to true in
 # Git, watch the rollback, flip it back.
-forceUnhealthy: false
+forceUnhealthy: true
 
 nodeSelector: {}
 


### PR DESCRIPTION
Second rehearsal of the rollback demo, now with the Prometheus-based canary analysis (#115). Expected: canary never Ready, AnalysisRun fails, Rollout aborts back to stable. Will be reverted right after.