### PR TITLE
feat(monitoring): reserve the observability node with a NoSchedule taint

### DIFF
--- a/helm/monitoring/loki-values.yaml
+++ b/helm/monitoring/loki-values.yaml
@@ -53,6 +53,11 @@ singleBinary:
     size: 5Gi
   nodeSelector:
     workload: monitoring
+  tolerations:
+    - key: workload
+      operator: Equal
+      value: monitoring
+      effect: NoSchedule
 
 backend:
   replicas: 0

--- a/helm/monitoring/values.yaml
+++ b/helm/monitoring/values.yaml
@@ -10,14 +10,21 @@
 #     — pas d'admin par défaut. Alertmanager reste hors scope.
 #   - Stockage emptyDir + rétention courte : VMs limitées et éteintes le soir.
 #   - Stack lourde épinglée sur le nœud monitoring dédié (label workload=monitoring).
+#   - Nœud RÉSERVÉ à l'observabilité : taint workload=monitoring:NoSchedule sur le
+#     nœud, d'où la toleration en plus du nodeSelector sur chaque composant pinné.
 
 # --- Scope : Visualisation (Grafana, OIDC Dex) — alerting hors scope ---
 grafana:
   enabled: true
 
-  # Ordonnancement sur le nœud dédié monitoring
+  # Ordonnancement sur le nœud dédié monitoring (réservé par une taint)
   nodeSelector:
     workload: monitoring
+  tolerations:
+    - key: workload
+      operator: Equal
+      value: monitoring
+      effect: NoSchedule
 
   # Rétention et stockage temporaire (emptyDir pour la démo)
   persistence:
@@ -86,6 +93,11 @@ alertmanager:
 prometheusOperator:
   nodeSelector:
     workload: monitoring
+  tolerations:
+    - key: workload
+      operator: Equal
+      value: monitoring
+      effect: NoSchedule
   resources:
     requests:
       cpu: 50m
@@ -103,9 +115,14 @@ prometheus:
     # Stockage éphémère : aucun storageSpec => le chart monte un emptyDir.
     # L'historique est perdu au restart du pod — acceptable pour la démo.
 
-    # Ordonnancement sur le nœud dédié.
+    # Ordonnancement sur le nœud dédié (réservé par une taint).
     nodeSelector:
       workload: monitoring
+    tolerations:
+      - key: workload
+        operator: Equal
+        value: monitoring
+        effect: NoSchedule
 
     # CLÉ pour « scraper les apps qui déclarent des endpoints » : par défaut
     # Prometheus ne sélectionne que les ServiceMonitor portant le label de la
@@ -127,6 +144,11 @@ prometheus:
 kube-state-metrics:
   nodeSelector:
     workload: monitoring
+  tolerations:
+    - key: workload
+      operator: Equal
+      value: monitoring
+      effect: NoSchedule
   resources:
     requests:
       cpu: 20m

--- a/k8s/monitoring/README.md
+++ b/k8s/monitoring/README.md
@@ -116,22 +116,32 @@ workers), so we designate one worker with a label:
 # Pick the worker that does NOT run mysql-0 (its local-path PVC pins it there):
 kubectl get pod -n mysql -o wide        # note the NODE of mysql-0
 kubectl label node <other-worker> workload=monitoring
+kubectl taint node <other-worker> workload=monitoring:NoSchedule
 ```
 
-The heavy components (Prometheus, Prometheus Operator, kube-state-metrics) carry
-`nodeSelector: workload=monitoring` in `values.yaml`. **`node-exporter` is the
-exception**: it is a DaemonSet with a broad toleration so it runs on *every* node
-(including the tainted master) to report each node's metrics — restricting it to
-the monitoring node would lose the other nodes' metrics.
+The heavy components (Prometheus, Prometheus Operator, Grafana, Loki,
+kube-state-metrics) carry `nodeSelector: workload=monitoring` **and** the
+matching toleration in `values.yaml` / `loki-values.yaml`. **`node-exporter` and
+`promtail` are the exception**: they are DaemonSets with a broad toleration so
+they run on *every* node (including the tainted master) to report each node's
+metrics/logs — restricting them to the monitoring node would lose the other
+nodes' signals.
 
 > **Prerequisite:** apply the label **before** Argo CD syncs, otherwise the
 > Prometheus pod stays `Pending` (nodeSelector unsatisfied). That is expected,
-> not a bug. We use a `nodeSelector` (attract) rather than a taint (reserve) to
-> avoid evicting MySQL, which is fine for the criterion.
+> not a bug.
 >
-> GitOps evolution: set `--node-labels=workload=monitoring` on the chosen
-> worker's `kubeadm join` in the Ansible `workers` role, so the label is
-> reproducible if the cluster is recreated.
+> The node is **reserved** for observability: the `nodeSelector` attracts the
+> stack, the `NoSchedule` taint keeps everything else off. `NoSchedule` does not
+> evict pods already running there — after tainting, delete any lingering
+> non-monitoring pods (their controllers reschedule them elsewhere). Also note
+> that Loki's `local-path` PVC pins it to this node anyway, so the reservation
+> also formalises that existing constraint.
+>
+> GitOps evolution: set `--node-labels=workload=monitoring` and
+> `--register-with-taints=workload=monitoring:NoSchedule` on the chosen worker's
+> kubelet in the Ansible `workers` role, so both are reproducible if the cluster
+> is recreated.
 
 ## Access (not public without auth)
 **Prometheus** stays internal: a **ClusterIP** Service, no Ingress. Grafana

--- a/k8s/monitoring/loki.yaml
+++ b/k8s/monitoring/loki.yaml
@@ -368,6 +368,11 @@ spec:
             topologyKey: kubernetes.io/hostname
       nodeSelector:
         workload: monitoring
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: monitoring
       volumes:
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
## Contexte
Le nœud `ip-10-2-41-182` porte déjà le label `workload=monitoring` et toute la stack observabilité y est épinglée via `nodeSelector`, mais rien n'empêchait les autres workloads d'y atterrir (les jobs `mysql-backup`, argocd-redis, kuard, etc. y tournaient).

## Changements
- Ajout de la toleration `workload=monitoring:NoSchedule` sur tous les composants pinnés : Prometheus, Prometheus Operator, Grafana, kube-state-metrics (`helm/monitoring/values.yaml`) et Loki (`helm/monitoring/loki-values.yaml`).
- Manifests vendorés regénérés (`helm template`, versions épinglées inchangées : kube-prometheus-stack 86.3.1, loki 7.0.0) — le diff ne contient que les tolerations.
- `node-exporter` et `promtail` restent des DaemonSets à toleration large (ils doivent tourner sur tous les nœuds).
- README mis à jour : le nœud passe de « attract » (label seul) à « reserve » (label + taint), avec la piste `--register-with-taints` côté Ansible pour la reproductibilité.

## Opérations cluster
La taint `workload=monitoring:NoSchedule` a été appliquée sur `ip-10-2-41-182`. Elle n'évince pas les pods existants ; les pods non-monitoring encore présents migreront à leur prochain rescheduling (ou via un delete manuel après merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA31eczJvDowX5W5iWQjnh